### PR TITLE
refactor: implement relative import paths

### DIFF
--- a/contracts/src/bridges/AcrossBridgeGateway.sol
+++ b/contracts/src/bridges/AcrossBridgeGateway.sol
@@ -5,11 +5,11 @@ pragma solidity >=0.8.28;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // Superform
-import { SuperRegistryImplementer } from "src/utils/SuperRegistryImplementer.sol";
+import { SuperRegistryImplementer } from "../utils/SuperRegistryImplementer.sol";
 
-import { ISuperGatewayExecutorV2 } from "src/interfaces/ISuperGatewayExecutorV2.sol";
-import { IAcrossV3Receiver } from "src/interfaces/vendors/bridges/across/IAcrossV3Receiver.sol";
-import { IAcrossV3Interpreter } from "src/interfaces/vendors/bridges/across/IAcrossV3Interpreter.sol";
+import { ISuperGatewayExecutorV2 } from "../interfaces/ISuperGatewayExecutorV2.sol";
+import { IAcrossV3Receiver } from "../interfaces/vendors/bridges/across/IAcrossV3Receiver.sol";
+import { IAcrossV3Interpreter } from "../interfaces/vendors/bridges/across/IAcrossV3Interpreter.sol";
 
 contract AcrossBridgeGateway is IAcrossV3Receiver, SuperRegistryImplementer {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/src/executors/BaseExecutorModule.sol
+++ b/contracts/src/executors/BaseExecutorModule.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.28;
 
 // Superform    
-import { SuperRegistryImplementer } from "src/utils/SuperRegistryImplementer.sol";
+import { SuperRegistryImplementer } from "../utils/SuperRegistryImplementer.sol";
 
 contract BaseExecutorModule is SuperRegistryImplementer {
     // forgefmt: disable-start

--- a/contracts/src/executors/SuperExecutorV2.sol
+++ b/contracts/src/executors/SuperExecutorV2.sol
@@ -7,11 +7,11 @@ import { ERC7579ExecutorBase } from "modulekit/Modules.sol";
 // Superform
 import { BaseExecutorModule } from "./BaseExecutorModule.sol";
 
-import { ISuperHook } from "src/interfaces/ISuperHook.sol";
-import { ISuperRbac } from "src/interfaces/ISuperRbac.sol";
-import { ISentinel } from "src/interfaces/sentinel/ISentinel.sol";
-import { ISuperExecutorV2 } from "src/interfaces/ISuperExecutorV2.sol";
-import { ISuperActions } from "src/interfaces/strategies/ISuperActions.sol";
+import { ISuperHook } from "../interfaces/ISuperHook.sol";
+import { ISuperRbac } from "../interfaces/ISuperRbac.sol";
+import { ISentinel } from "../interfaces/sentinel/ISentinel.sol";
+import { ISuperExecutorV2 } from "../interfaces/ISuperExecutorV2.sol";
+import { ISuperActions } from "../interfaces/strategies/ISuperActions.sol";
 
 contract SuperExecutorV2 is BaseExecutorModule, ERC7579ExecutorBase, ISuperExecutorV2 {
     constructor(address registry_) BaseExecutorModule(registry_) { }

--- a/contracts/src/executors/SuperGatewayExecutorV2.sol
+++ b/contracts/src/executors/SuperGatewayExecutorV2.sol
@@ -13,13 +13,13 @@ import { ERC7579ExecutorBase } from "modulekit/Modules.sol";
 
 // Superform
 import { BaseExecutorModule } from "./BaseExecutorModule.sol";
-import { ISuperHook } from "src/interfaces/ISuperHook.sol";
-import { ISentinel } from "src/interfaces/sentinel/ISentinel.sol";
-import { ISuperExecutorV2 } from "src/interfaces/ISuperExecutorV2.sol";
-import { ISuperActions } from "src/interfaces/strategies/ISuperActions.sol";
-import { IAcrossV3Interpreter } from "src/interfaces/vendors/bridges/across/IAcrossV3Interpreter.sol";
-import { ISuperRbac } from "src/interfaces/ISuperRbac.sol";
-import { ISuperGatewayExecutorV2 } from "src/interfaces/ISuperGatewayExecutorV2.sol";
+import { ISuperHook } from "../interfaces/ISuperHook.sol";
+import { ISentinel } from "../interfaces/sentinel/ISentinel.sol";
+import { ISuperExecutorV2 } from "../interfaces/ISuperExecutorV2.sol";
+import { ISuperActions } from "../interfaces/strategies/ISuperActions.sol";
+import { IAcrossV3Interpreter } from "../interfaces/vendors/bridges/across/IAcrossV3Interpreter.sol";
+import { ISuperRbac } from "../interfaces/ISuperRbac.sol";
+import { ISuperGatewayExecutorV2 } from "../interfaces/ISuperGatewayExecutorV2.sol";
 
 // TODO: test cross-chain execution; This contract might be merged with SuperExecutorV2 once we have an execution flow
 // tested

--- a/contracts/src/hooks/bridges/across/AcrossExecuteOnDestinationHook.sol
+++ b/contracts/src/hooks/bridges/across/AcrossExecuteOnDestinationHook.sol
@@ -6,11 +6,11 @@ import { Execution } from "modulekit/Accounts.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 // Superform
-import { BaseHook } from "src/hooks/BaseHook.sol";
+import { BaseHook } from "../../BaseHook.sol";
 
-import { ISuperHook } from "src/interfaces/ISuperHook.sol";
-import { IAcrossSpokePoolV3 } from "src/interfaces/vendors/bridges/across/IAcrossSpokePoolV3.sol";
-import { IAcrossV3Interpreter } from "src/interfaces/vendors/bridges/across/IAcrossV3Interpreter.sol";
+import { ISuperHook } from "../../../interfaces/ISuperHook.sol";
+import { IAcrossSpokePoolV3 } from "../../../interfaces/vendors/bridges/across/IAcrossSpokePoolV3.sol";
+import { IAcrossV3Interpreter } from "../../../interfaces/vendors/bridges/across/IAcrossV3Interpreter.sol";
 
 contract AcrossExecuteOnDestinationHook is BaseHook, ISuperHook {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/src/hooks/tokens/erc20/ApproveERC20Hook.sol
+++ b/contracts/src/hooks/tokens/erc20/ApproveERC20Hook.sol
@@ -6,9 +6,9 @@ import { Execution } from "modulekit/Accounts.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 // Superform
-import { BaseHook } from "src/hooks/BaseHook.sol";
+import { BaseHook } from "../../BaseHook.sol";
 
-import { ISuperHook } from "src/interfaces/ISuperHook.sol";
+import { ISuperHook } from "../../../interfaces/ISuperHook.sol";
 
 contract ApproveERC20Hook is BaseHook, ISuperHook {
     constructor(address registry_, address author_) BaseHook(registry_, author_) { }

--- a/contracts/src/interfaces/vendors/standards/erc4337/IEntryPoint.sol
+++ b/contracts/src/interfaces/vendors/standards/erc4337/IEntryPoint.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { IUserOperation } from "src/interfaces/vendors/standards/erc4337/IUserOperation.sol";
+import { IUserOperation } from "./IUserOperation.sol";
 
 interface IEntryPoint {
     /**

--- a/contracts/src/sentinels/SuperPositionSentinel.sol
+++ b/contracts/src/sentinels/SuperPositionSentinel.sol
@@ -2,9 +2,9 @@
 pragma solidity >=0.8.28;
 
 // Superform
-import { ISentinel } from "src/interfaces/sentinel/ISentinel.sol";
+import { ISentinel } from "../interfaces/sentinel/ISentinel.sol";
 
-import { SuperRegistryImplementer } from "src/utils/SuperRegistryImplementer.sol";
+import { SuperRegistryImplementer } from "../utils/SuperRegistryImplementer.sol";
 
 contract SuperPositionSentinel is ISentinel, SuperRegistryImplementer {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/src/settings/SuperRbac.sol
+++ b/contracts/src/settings/SuperRbac.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.28;
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 // Superform
-import { ISuperRbac } from "src/interfaces/ISuperRbac.sol";
+import { ISuperRbac } from "../interfaces/ISuperRbac.sol";
 
 contract SuperRbac is Ownable, ISuperRbac {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/src/state/SharedState.sol
+++ b/contracts/src/state/SharedState.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.8.28;
 
 // Superform
-import { ISharedStateWriter } from "src/interfaces/state/ISharedStateWriter.sol";
-import { ISharedStateReader } from "src/interfaces/state/ISharedStateReader.sol";
+import { ISharedStateWriter } from "../interfaces/state/ISharedStateWriter.sol";
+import { ISharedStateReader } from "../interfaces/state/ISharedStateReader.sol";
 
 contract SharedState is ISharedStateWriter, ISharedStateReader {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/src/strategies/SuperActions.sol
+++ b/contracts/src/strategies/SuperActions.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.28;
 
-import { SuperRegistryImplementer } from "src/utils/SuperRegistryImplementer.sol";
-import { ISuperRbac } from "src/interfaces/ISuperRbac.sol";
-import { ISuperActions } from "src/interfaces/strategies/ISuperActions.sol";
-import { IERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import { SuperRegistryImplementer } from "../utils/SuperRegistryImplementer.sol";
+import { ISuperRbac } from "../interfaces/ISuperRbac.sol";
+import { ISuperActions } from "../interfaces/strategies/ISuperActions.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @dev delete this later
 interface IActionOracle {

--- a/contracts/src/strategies/SuperPositionsMock.sol
+++ b/contracts/src/strategies/SuperPositionsMock.sol
@@ -4,9 +4,9 @@ pragma solidity >=0.8.28;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 // superform
-import { ISuperRegistry } from "src/interfaces/ISuperRegistry.sol";
-import { ISuperPositions } from "src/interfaces/strategies/ISuperPositions.sol";
-import { SuperRegistryImplementer } from "src/utils/SuperRegistryImplementer.sol";
+import { ISuperRegistry } from "../interfaces/ISuperRegistry.sol";
+import { ISuperPositions } from "../interfaces/strategies/ISuperPositions.sol";
+import { SuperRegistryImplementer } from "../utils/SuperRegistryImplementer.sol";
 
 contract SuperPositionsMock is ISuperPositions, ERC20, SuperRegistryImplementer {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/src/utils/SuperRegistryImplementer.sol
+++ b/contracts/src/utils/SuperRegistryImplementer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { ISuperRegistry } from "src/interfaces/ISuperRegistry.sol";
+import { ISuperRegistry } from "../interfaces/ISuperRegistry.sol";
 
 abstract contract SuperRegistryImplementer {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/test/BaseTest.t.sol
+++ b/contracts/test/BaseTest.t.sol
@@ -6,27 +6,27 @@ import { AccountInstance } from "modulekit/ModuleKit.sol";
 
 import { Helpers } from "./utils/Helpers.sol";
 
-import { SpokePoolV3Mock } from "test/mocks/SpokePoolV3Mock.sol";
+import { SpokePoolV3Mock } from "./mocks/SpokePoolV3Mock.sol";
 
-import { SuperRegistry } from "src/settings/SuperRegistry.sol";
-import { ISuperRegistry } from "src/interfaces/ISuperRegistry.sol";
+import { SuperRegistry } from "../src/settings/SuperRegistry.sol";
+import { ISuperRegistry } from "../src/interfaces/ISuperRegistry.sol";
 
 // tokens hooks
 // --- erc20
-import { ApproveERC20Hook } from "src/hooks/tokens/erc20/ApproveERC20Hook.sol";
-import { TransferERC20Hook } from "src/hooks/tokens/erc20/TransferERC20Hook.sol";
+import { ApproveERC20Hook } from "../src/hooks/tokens/erc20/ApproveERC20Hook.sol";
+import { TransferERC20Hook } from "../src/hooks/tokens/erc20/TransferERC20Hook.sol";
 // vault hooks
 // --- erc5115
-import { Deposit5115VaultHook } from "src/hooks/vaults/5115/Deposit5115VaultHook.sol";
-import { Withdraw5115VaultHook } from "src/hooks/vaults/5115/Withdraw5115VaultHook.sol";
+import { Deposit5115VaultHook } from "../src/hooks/vaults/5115/Deposit5115VaultHook.sol";
+import { Withdraw5115VaultHook } from "../src/hooks/vaults/5115/Withdraw5115VaultHook.sol";
 // --- erc4626
-import { Deposit4626VaultHook } from "src/hooks/vaults/4626/Deposit4626VaultHook.sol";
-import { Withdraw4626VaultHook } from "src/hooks/vaults/4626/Withdraw4626VaultHook.sol";
+import { Deposit4626VaultHook } from "../src/hooks/vaults/4626/Deposit4626VaultHook.sol";
+import { Withdraw4626VaultHook } from "../src/hooks/vaults/4626/Withdraw4626VaultHook.sol";
 // -- erc7540
-import { RequestDeposit7540VaultHook } from "src/hooks/vaults/7540/RequestDeposit7540VaultHook.sol";
-import { RequestWithdraw7540VaultHook } from "src/hooks/vaults/7540/RequestWithdraw7540VaultHook.sol";
+import { RequestDeposit7540VaultHook } from "../src/hooks/vaults/7540/RequestDeposit7540VaultHook.sol";
+import { RequestWithdraw7540VaultHook } from "../src/hooks/vaults/7540/RequestWithdraw7540VaultHook.sol";
 // bridges hooks
-import { AcrossExecuteOnDestinationHook } from "src/hooks/bridges/across/AcrossExecuteOnDestinationHook.sol";
+import { AcrossExecuteOnDestinationHook } from "../src/hooks/bridges/across/AcrossExecuteOnDestinationHook.sol";
 
 abstract contract BaseTest is Helpers {
     /*//////////////////////////////////////////////////////////////

--- a/contracts/test/mocks/Mock5115Vault.sol
+++ b/contracts/test/mocks/Mock5115Vault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { IERC20 } from "openzeppelin-contracts/contracts/interfaces/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 contract Mock5115Vault {
   constructor(

--- a/contracts/test/unit/Mock/Mock.t.sol
+++ b/contracts/test/unit/Mock/Mock.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { BaseTest } from "test/BaseTest.t.sol";
+import { BaseTest } from "../../BaseTest.t.sol";
 
-import { MockSignature } from "test/mocks/MockSignature.sol";
-import { TransientStorageExecutor } from "test/mocks/TransientStorageExecutor.sol";
+import { MockSignature } from "../../mocks/MockSignature.sol";
+import { TransientStorageExecutor } from "../../mocks/TransientStorageExecutor.sol";
 
 contract Mocktsol is BaseTest {
     TransientStorageExecutor transientExecutor;

--- a/contracts/test/unit/SuperExecutor/SuperExecutor_sameChainFlow.t.sol
+++ b/contracts/test/unit/SuperExecutor/SuperExecutor_sameChainFlow.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.28;
 
-import { ISuperExecutorV2 } from "src/interfaces/ISuperExecutorV2.sol";
-import { Unit_Shared } from "test/unit/Unit_Shared.t.sol";
-import { ISuperActions } from "src/interfaces/strategies/ISuperActions.sol";
-import { SuperPositionSentinel } from "src/sentinels/SuperPositionSentinel.sol";
+import { ISuperExecutorV2 } from "../../../src/interfaces/ISuperExecutorV2.sol";
+import { Unit_Shared } from "../Unit_Shared.t.sol";
+import { ISuperActions } from "../../../src/interfaces/strategies/ISuperActions.sol";
+import { SuperPositionSentinel } from "../../../src/sentinels/SuperPositionSentinel.sol";
 
 contract SuperExecutor_sameChainFlow is Unit_Shared {
     address RANDOM_TARGET = address(uint160(uint256(keccak256(abi.encodePacked(block.timestamp, address(this))))));

--- a/contracts/test/unit/Unit_Shared.t.sol
+++ b/contracts/test/unit/Unit_Shared.t.sol
@@ -21,19 +21,19 @@ import { ISuperGatewayExecutorV2 } from "src/interfaces/ISuperGatewayExecutorV2.
 import { ISuperActions } from "src/interfaces/strategies/ISuperActions.sol";
 import { ISentinel } from "src/interfaces/sentinel/ISentinel.sol";
 
-import { SuperRbac } from "src/settings/SuperRbac.sol";
-import { SharedState } from "src/state/SharedState.sol";
-import { SuperRegistry } from "src/settings/SuperRegistry.sol";
-import { SuperExecutorV2 } from "src/executors/SuperExecutorV2.sol";
-import { SuperActions } from "src/strategies/SuperActions.sol";
-import { SuperPositionSentinel } from "src/sentinels/SuperPositionSentinel.sol";
-import { SuperGatewayExecutorV2 } from "src/executors/SuperGatewayExecutorV2.sol";
-import { SuperPositionSentinel } from "src/sentinels/SuperPositionSentinel.sol";
+import { SuperRbac } from "../../src/settings/SuperRbac.sol";
+import { SharedState } from "../../src/state/SharedState.sol";
+import { SuperRegistry } from "../../src/settings/SuperRegistry.sol";
+import { SuperExecutorV2 } from "../../src/executors/SuperExecutorV2.sol";
+import { SuperActions } from "../../src/strategies/SuperActions.sol";
+import { SuperPositionSentinel } from "../../src/sentinels/SuperPositionSentinel.sol";
+import { SuperGatewayExecutorV2 } from "../../src/executors/SuperGatewayExecutorV2.sol";
+import { SuperPositionSentinel } from "../../src/sentinels/SuperPositionSentinel.sol";
 
-import { MockERC20 } from "test/mocks/MockERC20.sol";
-import { Mock4626Vault } from "test/mocks/Mock4626Vault.sol";
+import { MockERC20 } from "../mocks/MockERC20.sol";
+import { Mock4626Vault } from "../mocks/Mock4626Vault.sol";
 
-import { BaseTest } from "test/BaseTest.t.sol";
+import { BaseTest } from "../BaseTest.t.sol";
 
 abstract contract Unit_Shared is BaseTest, RhinestoneModuleKit {
     using ModuleKitHelpers for *;

--- a/contracts/test/unit/libraries/Deposit4626Library.t.sol
+++ b/contracts/test/unit/libraries/Deposit4626Library.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { BaseTest } from "test/BaseTest.t.sol";
-import { MockERC20 } from "test/mocks/MockERC20.sol";
-import { Mock4626Vault } from "test/mocks/Mock4626Vault.sol";
-import { Deposit4626Library } from "src/libraries/strategies/Deposit4626Library.sol";
+import { BaseTest } from "../../BaseTest.t.sol";
+import { MockERC20 } from "../../mocks/MockERC20.sol";
+import { Mock4626Vault } from "../../mocks/Mock4626Vault.sol";
+import { Deposit4626Library } from "../../../src/libraries/strategies/Deposit4626Library.sol";
 
 contract Deposit4626LibraryTest is BaseTest {
   Mock4626Vault vault;

--- a/contracts/test/unit/libraries/Deposit5115Library.t.sol
+++ b/contracts/test/unit/libraries/Deposit5115Library.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { BaseTest } from "test/BaseTest.t.sol";
-import { Helpers } from "test/utils/Helpers.sol";
-import { MockERC20 } from "test/mocks/MockERC20.sol";
-import { Mock5115Vault } from "test/mocks/Mock5115Vault.sol";
-import { Deposit5115Library } from "src/libraries/strategies/Deposit5115Library.sol";
+import { BaseTest } from "../../BaseTest.t.sol";
+import { Helpers } from "../../utils/Helpers.sol";
+import { MockERC20 } from "../../mocks/MockERC20.sol";
+import { Mock5115Vault } from "../../mocks/Mock5115Vault.sol";
+import { Deposit5115Library } from "../../../src/libraries/strategies/Deposit5115Library.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 

--- a/contracts/test/unit/libraries/Looped4626DepositLibrary.t.sol
+++ b/contracts/test/unit/libraries/Looped4626DepositLibrary.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import { BaseTest } from "test/BaseTest.t.sol";
-import { MockERC20 } from "test/mocks/MockERC20.sol";
-import { Mock4626Vault } from "test/mocks/Mock4626Vault.sol";
-import { Looped4626DepositLibrary } from "src/libraries/strategies/Looped4626DepositLibrary.sol";
+import { BaseTest } from "../../BaseTest.t.sol";
+import { MockERC20 } from "../../mocks/MockERC20.sol";
+import { Mock4626Vault } from "../../mocks/Mock4626Vault.sol";
+import { Looped4626DepositLibrary } from "../../../src/libraries/strategies/Looped4626DepositLibrary.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 

--- a/contracts/test/utils/Helpers.sol
+++ b/contracts/test/utils/Helpers.sol
@@ -7,7 +7,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // Superform
 import { Constants } from "./Constants.sol";
-import { MockERC20 } from "test/mocks/MockERC20.sol";
+import { MockERC20 } from "../mocks/MockERC20.sol";
 
 abstract contract Helpers is Test, Constants {
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
Goal: Make sure v2-core is compatible with any projects that import it as a foundry lib and build on top

Solution: change all imports to relative imports ("../../") to avoid remapping issues with src/