### PR TITLE
fix: change key value to string in bridging test

### DIFF
--- a/test/integration/BridgeToMultiVaultDepositAndRedeemFlow.t.sol
+++ b/test/integration/BridgeToMultiVaultDepositAndRedeemFlow.t.sol
@@ -64,6 +64,9 @@ contract BridgeToMultiVaultDepositAndRedeemFlow is BaseTest {
     bytes16 public trancheId;
     uint128 public assetId;
 
+    string public constant YIELD_SOURCE_7540_ETH_USDC_KEY = "YieldSource_7540_ETH_USDC";
+    string public constant YIELD_SOURCE_ORACLE_7540_KEY = "YieldSourceOracle_7540";
+
     /*//////////////////////////////////////////////////////////////
                                 SETUP
     //////////////////////////////////////////////////////////////*/
@@ -80,12 +83,12 @@ contract BridgeToMultiVaultDepositAndRedeemFlow is BaseTest {
         // Set up the 7540 yield source
         yieldSource7540AddressETH_USDC =
             realVaultAddresses[ETH][ERC7540FullyAsync_KEY][CENTRIFUGE_USDC_VAULT_KEY][USDC_KEY];
-        vm.label(yieldSource7540AddressETH_USDC, "YieldSource_7540_ETH_USDC");
+        vm.label(yieldSource7540AddressETH_USDC, YIELD_SOURCE_7540_ETH_USDC_KEY);
 
         vaultInstance7540ETH = IERC7540(yieldSource7540AddressETH_USDC);
 
         yieldSourceOracle7540 = _getContract(ETH, ERC7540_YIELD_SOURCE_ORACLE_KEY);
-        vm.label(yieldSourceOracle7540, "YieldSourceOracle_7540");
+        vm.label(yieldSourceOracle7540, YIELD_SOURCE_ORACLE_7540_KEY);
 
         // Set up the 4626 yield source
         yieldSource4626AddressOP_USDCe = realVaultAddresses[OP][ERC4626_VAULT_KEY][ALOE_USDC_VAULT_KEY][USDCe_KEY];


### PR DESCRIPTION
Changing the yield source oracle labels to keys broke the build, this PR reverts them to strings to fix that. 