### PR TITLE
Adding ICC Whitelist and function to manipulate it for the SuperGovernor Role

### DIFF
--- a/src/periphery/SuperGovernor.sol
+++ b/src/periphery/SuperGovernor.sol
@@ -223,6 +223,24 @@ contract SuperGovernor is ISuperGovernor, AccessControl {
         factory.setSuperAssetManager(superAsset, _superAssetManager);
     }
 
+    /// @inheritdoc ISuperGovernor
+    function addICCToWhitelist(address icc) external onlyRole(_SUPER_GOVERNOR_ROLE) {
+        if (icc == address(0)) revert INVALID_ADDRESS();
+        address value = _addressRegistry[_SUPER_ASSET_FACTORY];
+        if (value == address(0)) revert CONTRACT_NOT_FOUND();
+        ISuperAssetFactory factory = ISuperAssetFactory(value);
+        factory.addICCToWhitelist(icc);
+    }
+
+    /// @inheritdoc ISuperGovernor
+    function removeICCFromWhitelist(address icc) external onlyRole(_SUPER_GOVERNOR_ROLE) {
+        if (icc == address(0)) revert INVALID_ADDRESS();
+        address value = _addressRegistry[_SUPER_ASSET_FACTORY];
+        if (value == address(0)) revert CONTRACT_NOT_FOUND();
+        ISuperAssetFactory factory = ISuperAssetFactory(value);
+        factory.removeICCFromWhitelist(icc);
+    }
+
     /// @notice Proposes a new global hooks Merkle root in the SuperVaultAggregator
     /// @dev Only callable by GOVERNOR_ROLE
     /// @param newRoot New Merkle root for global hooks validation

--- a/src/periphery/interfaces/ISuperGovernor.sol
+++ b/src/periphery/interfaces/ISuperGovernor.sol
@@ -608,4 +608,12 @@ interface ISuperGovernor is IAccessControl {
     /// @notice Removes a strategist from the superform strategists list
     /// @param strategist Address of the strategist to remove
     function removeSuperformStrategist(address strategist) external;
+
+    /// @notice Adds a new ICC to the whitelist
+    /// @param icc Address of the ICC to add
+    function addICCToWhitelist(address icc) external;
+
+    /// @notice Removes an ICC from the whitelist
+    /// @param icc Address of the ICC to remove
+    function removeICCFromWhitelist(address icc) external;
 }

--- a/src/periphery/interfaces/SuperAsset/ISuperAssetFactory.sol
+++ b/src/periphery/interfaces/SuperAsset/ISuperAssetFactory.sol
@@ -106,6 +106,25 @@ interface ISuperAssetFactory {
     function getIncentiveFundContract(address superAsset) external view returns (address);
 
     /**
+     * @notice Adds an Incentive Calculation Contract to the whitelist
+     * @param icc Address of the Incentive Calculation Contract
+     */
+    function addICCToWhitelist(address icc) external;
+
+    /**
+     * @notice Removes an Incentive Calculation Contract from the whitelist
+     * @param icc Address of the Incentive Calculation Contract
+     */
+    function removeICCFromWhitelist(address icc) external;
+
+    /**
+     * @notice Checks if an Incentive Calculation Contract is whitelisted
+     * @param icc Address of the Incentive Calculation Contract
+     * @return isValid Whether the Incentive Calculation Contract is whitelisted
+     */
+    function isICCWhitelisted(address icc) external view returns (bool);
+    
+    /**
      * @notice Creates a new SuperAsset instance with its dependencies
      * @param params Parameters for creating the SuperAsset
      * @return superAsset Address of the deployed SuperAsset contract
@@ -141,4 +160,7 @@ interface ISuperAssetFactory {
 
     // Unauthorized errors
     error UNAUTHORIZED();
+
+    // ICC errors
+    error ICC_NOT_WHITELISTED();
 }

--- a/test/periphery/integration/SuperAsset/IncentiveFundContract.t.sol
+++ b/test/periphery/integration/SuperAsset/IncentiveFundContract.t.sol
@@ -147,6 +147,7 @@ contract IncentiveFundContractTest is Helpers {
             makeAddr("treasury"), // treasury
             makeAddr("prover") // prover
         );
+        // Admin is SuperGovernor Role 
         console.log("SuperGovernor deployed");
 
         // Create SuperAsset using factory
@@ -166,6 +167,8 @@ contract IncentiveFundContractTest is Helpers {
         superGovernor.setAddress(superGovernor.SUPER_ASSET_FACTORY(), address(factory));
 
         console.log("SuperAssetFactory deployed");
+        // NOTE: Whitelisting ICC so that's possible to instantiate SuperAsset using it 
+        superGovernor.addICCToWhitelist(address(icc));
         (address superAssetAddr, address incentiveFundAddr) = factory.createSuperAsset(params);
         console.log("SuperAsset and IncentiveFund deployed via factory");
         superAsset = SuperAsset(superAssetAddr);


### PR DESCRIPTION
Adding an ICC whitelist with permissioned functions to manipulate it, that is used to check the ICC associated to a SuperAsset by a strategist is valid 