### PR TITLE
feat: sup 12973 fix issue 63 in periphery audit

### DIFF
--- a/src/hooks/BaseHook.sol
+++ b/src/hooks/BaseHook.sol
@@ -214,7 +214,7 @@ abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult, IS
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure virtual returns (bytes memory) { }
+    function inspect(bytes calldata data) external view virtual returns (bytes memory) { }
 
     /*//////////////////////////////////////////////////////////////
                                  INTERNAL METHODS

--- a/src/hooks/BaseHook.sol
+++ b/src/hooks/BaseHook.sol
@@ -5,7 +5,8 @@ pragma solidity 0.8.30;
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 
 // Superform
-import { ISuperHook, ISuperHookSetter, ISuperHookResult } from "../interfaces/ISuperHook.sol";
+import { HookDataDecoder } from "../libraries/HookDataDecoder.sol";
+import { ISuperHook, ISuperHookSetter, ISuperHookResult, ISuperHookInspector } from "../interfaces/ISuperHook.sol";
 
 /// @title BaseHook
 /// @author Superform Labs
@@ -14,7 +15,9 @@ import { ISuperHook, ISuperHookSetter, ISuperHookResult } from "../interfaces/IS
 ///      All specialized hooks should inherit from this base contract
 ///      Implements the ISuperHook interface defined lifecycle methods
 ///      Uses a transient storage pattern for stateful execution context
-abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult {
+abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult, ISuperHookInspector {
+    using HookDataDecoder for bytes;
+
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -208,6 +211,13 @@ abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult {
     /// @inheritdoc ISuperHook
     function subtype() external view returns (bytes32) {
         return subType;
+    }
+
+    /// @inheritdoc ISuperHookInspector
+    function inspect(bytes calldata data) external pure returns (bytes memory) {
+        return abi.encodePacked(
+            data.extractYieldSource()
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/BaseHook.sol
+++ b/src/hooks/BaseHook.sol
@@ -214,11 +214,7 @@ abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult, IS
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
-        return abi.encodePacked(
-            data.extractYieldSource()
-        );
-    }
+    function inspect(bytes calldata data) external pure virtual returns (bytes memory) { }
 
     /*//////////////////////////////////////////////////////////////
                                  INTERNAL METHODS

--- a/src/hooks/bridges/across/AcrossSendFundsAndExecuteOnDstHook.sol
+++ b/src/hooks/bridges/across/AcrossSendFundsAndExecuteOnDstHook.sol
@@ -33,7 +33,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         uint32 exclusivityPeriod = BytesLib.toUint32(data, 212);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 216);
 /// @notice         bytes destinationMessage = BytesLib.slice(data, 217, data.length - 217);
-contract AcrossSendFundsAndExecuteOnDstHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract AcrossSendFundsAndExecuteOnDstHook is BaseHook, ISuperHookContextAware {
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/

--- a/src/hooks/bridges/across/AcrossSendFundsAndExecuteOnDstHook.sol
+++ b/src/hooks/bridges/across/AcrossSendFundsAndExecuteOnDstHook.sol
@@ -174,7 +174,7 @@ contract AcrossSendFundsAndExecuteOnDstHook is BaseHook, ISuperHookContextAware 
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             BytesLib.toAddress(data, 32), // recipient
             BytesLib.toAddress(data, 52), // inputToken

--- a/src/hooks/bridges/debridge/DeBridgeCancelOrderHook.sol
+++ b/src/hooks/bridges/debridge/DeBridgeCancelOrderHook.sol
@@ -65,7 +65,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// giveTokenAddress_paramLength + takeTokenAddress_paramLength + receiverDst_paramLength +
 /// givePatchAuthoritySrc_paramLength + orderAuthorityAddressDst_paramLength + allowedTakerDst_paramLength +
 /// allowedCancelBeneficiarySrc_paramLength);
-contract DeBridgeCancelOrderHook is BaseHook, ISuperHookInspector {
+contract DeBridgeCancelOrderHook is BaseHook {
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/

--- a/src/hooks/bridges/debridge/DeBridgeCancelOrderHook.sol
+++ b/src/hooks/bridges/debridge/DeBridgeCancelOrderHook.sol
@@ -101,7 +101,7 @@ contract DeBridgeCancelOrderHook is BaseHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         (Order memory order,,) = _createOrder(data);
 
         return abi.encodePacked(

--- a/src/hooks/bridges/debridge/DeBridgeSendOrderAndExecuteOnDstHook.sol
+++ b/src/hooks/bridges/debridge/DeBridgeSendOrderAndExecuteOnDstHook.sol
@@ -70,7 +70,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         uint256 referralCode = BytesLib.toUint256(data, 468 + destinationMessage_paramLength +
 /// takeTokenAddress_paramLength + receiverDst_paramLength + orderAuthorityAddressDst_paramLength +
 /// allowedTakerDst_paramLength + allowedCancelBeneficiarySrc_paramLength + affiliateFee_paramLength);
-contract DeBridgeSendOrderAndExecuteOnDstHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract DeBridgeSendOrderAndExecuteOnDstHook is BaseHook, ISuperHookContextAware {
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/

--- a/src/hooks/bridges/debridge/DeBridgeSendOrderAndExecuteOnDstHook.sol
+++ b/src/hooks/bridges/debridge/DeBridgeSendOrderAndExecuteOnDstHook.sol
@@ -141,7 +141,7 @@ contract DeBridgeSendOrderAndExecuteOnDstHook is BaseHook, ISuperHookContextAwar
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         (IDlnSource.OrderCreation memory orderCreation,,,) = _createOrder(data, "");
 
         return abi.encodePacked(

--- a/src/hooks/claim/fluid/FluidClaimRewardHook.sol
+++ b/src/hooks/claim/fluid/FluidClaimRewardHook.sol
@@ -31,8 +31,7 @@ contract FluidClaimRewardHook is
     BaseClaimRewardHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/claim/fluid/FluidClaimRewardHook.sol
+++ b/src/hooks/claim/fluid/FluidClaimRewardHook.sol
@@ -73,7 +73,7 @@ contract FluidClaimRewardHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource(), BytesLib.toAddress(data, 52));
     }
 

--- a/src/hooks/claim/gearbox/GearboxClaimRewardHook.sol
+++ b/src/hooks/claim/gearbox/GearboxClaimRewardHook.sol
@@ -8,8 +8,6 @@ import { IGearboxFarmingPool } from "../../../vendor/gearbox/IGearboxFarmingPool
 
 // Superform
 import {
-    ISuperHook,
-    ISuperHookResultOutflow,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
     ISuperHookContextAware,

--- a/src/hooks/claim/gearbox/GearboxClaimRewardHook.sol
+++ b/src/hooks/claim/gearbox/GearboxClaimRewardHook.sol
@@ -72,7 +72,7 @@ contract GearboxClaimRewardHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource(), BytesLib.toAddress(data, 52));
     }
 

--- a/src/hooks/claim/gearbox/GearboxClaimRewardHook.sol
+++ b/src/hooks/claim/gearbox/GearboxClaimRewardHook.sol
@@ -32,8 +32,7 @@ contract GearboxClaimRewardHook is
     BaseClaimRewardHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/claim/yearn/YearnClaimOneRewardHook.sol
+++ b/src/hooks/claim/yearn/YearnClaimOneRewardHook.sol
@@ -11,8 +11,6 @@ import { BaseHook } from "../../BaseHook.sol";
 import { BaseClaimRewardHook } from "../BaseClaimRewardHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 import {
-    ISuperHook,
-    ISuperHookResultOutflow,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
     ISuperHookContextAware,

--- a/src/hooks/claim/yearn/YearnClaimOneRewardHook.sol
+++ b/src/hooks/claim/yearn/YearnClaimOneRewardHook.sol
@@ -73,7 +73,7 @@ contract YearnClaimOneRewardHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource(), BytesLib.toAddress(data, 52));
     }
 

--- a/src/hooks/claim/yearn/YearnClaimOneRewardHook.sol
+++ b/src/hooks/claim/yearn/YearnClaimOneRewardHook.sol
@@ -32,8 +32,7 @@ contract YearnClaimOneRewardHook is
     BaseClaimRewardHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/loan/morpho/MorphoBorrowHook.sol
+++ b/src/hooks/loan/morpho/MorphoBorrowHook.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
-import { IOracle } from "../../../vendor/morpho/IOracle.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";

--- a/src/hooks/loan/morpho/MorphoBorrowHook.sol
+++ b/src/hooks/loan/morpho/MorphoBorrowHook.sol
@@ -99,7 +99,7 @@ contract MorphoBorrowHook is BaseMorphoLoanHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         BorrowHookLocalVars memory vars = _decodeBorrowHookData(data);
 
         MarketParams memory marketParams =

--- a/src/hooks/loan/morpho/MorphoBorrowHook.sol
+++ b/src/hooks/loan/morpho/MorphoBorrowHook.sol
@@ -28,7 +28,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 144);
 /// @notice         uint256 lltv = BytesLib.toUint256(data, 145);
 /// @notice         bool placeholder = _decodeBool(data, 177);
-contract MorphoBorrowHook is BaseMorphoLoanHook, ISuperHookInspector {
+contract MorphoBorrowHook is BaseMorphoLoanHook {
     using HookDataDecoder for bytes;
 
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/loan/morpho/MorphoRepayAndWithdrawHook.sol
+++ b/src/hooks/loan/morpho/MorphoRepayAndWithdrawHook.sol
@@ -29,7 +29,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @notice         uint256 lltv = BytesLib.toUint256(data, 112);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 144);
 /// @notice         bool isFullRepayment = _decodeBool(data, 145);
-contract MorphoRepayAndWithdrawHook is BaseMorphoLoanHook, ISuperHookInspector {
+contract MorphoRepayAndWithdrawHook is BaseMorphoLoanHook {
     using MarketParamsLib for MarketParams;
     using HookDataDecoder for bytes;
     using SharesMathLib for uint256;

--- a/src/hooks/loan/morpho/MorphoRepayAndWithdrawHook.sol
+++ b/src/hooks/loan/morpho/MorphoRepayAndWithdrawHook.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.30;
 
 // external
-import { IIrm } from "../../../vendor/morpho/IIrm.sol";
-import { MathLib } from "../../../vendor/morpho/MathLib.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SharesMathLib } from "../../../vendor/morpho/SharesMathLib.sol";

--- a/src/hooks/loan/morpho/MorphoRepayAndWithdrawHook.sol
+++ b/src/hooks/loan/morpho/MorphoRepayAndWithdrawHook.sol
@@ -140,7 +140,7 @@ contract MorphoRepayAndWithdrawHook is BaseMorphoLoanHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         BuildHookLocalVars memory vars = _decodeHookData(data);
 
         MarketParams memory marketParams =

--- a/src/hooks/loan/morpho/MorphoRepayHook.sol
+++ b/src/hooks/loan/morpho/MorphoRepayHook.sol
@@ -115,7 +115,7 @@ contract MorphoRepayHook is BaseMorphoLoanHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         BuildHookLocalVars memory vars = _decodeHookData(data);
 
         MarketParams memory marketParams =

--- a/src/hooks/loan/morpho/MorphoRepayHook.sol
+++ b/src/hooks/loan/morpho/MorphoRepayHook.sol
@@ -26,7 +26,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @notice         uint256 lltv = BytesLib.toUint256(data, 112);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 144);
 /// @notice         bool isFullRepayment = _decodeBool(data, 145);
-contract MorphoRepayHook is BaseMorphoLoanHook, ISuperHookInspector {
+contract MorphoRepayHook is BaseMorphoLoanHook {
     using MarketParamsLib for MarketParams;
     using HookDataDecoder for bytes;
     using SharesMathLib for uint256;

--- a/src/hooks/loan/morpho/MorphoSupplyAndBorrowHook.sol
+++ b/src/hooks/loan/morpho/MorphoSupplyAndBorrowHook.sol
@@ -28,7 +28,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 144);
 /// @notice         uint256 lltv = BytesLib.toUint256(data, 145);
 /// @notice         bool placeholder = _decodeBool(data, 177);
-contract MorphoSupplyAndBorrowHook is BaseMorphoLoanHook, ISuperHookInspector {
+contract MorphoSupplyAndBorrowHook is BaseMorphoLoanHook {
     using HookDataDecoder for bytes;
 
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/loan/morpho/MorphoSupplyAndBorrowHook.sol
+++ b/src/hooks/loan/morpho/MorphoSupplyAndBorrowHook.sol
@@ -109,7 +109,7 @@ contract MorphoSupplyAndBorrowHook is BaseMorphoLoanHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         BorrowHookLocalVars memory vars = _decodeBorrowHookData(data);
 
         MarketParams memory marketParams =

--- a/src/hooks/loan/morpho/MorphoSupplyHook.sol
+++ b/src/hooks/loan/morpho/MorphoSupplyHook.sol
@@ -25,7 +25,7 @@ import { ISuperHook, ISuperHookInspector } from "../../../interfaces/ISuperHook.
 /// @notice         uint256 amount = BytesLib.toUint256(data, 80);
 /// @notice         uint256 lltv = BytesLib.toUint256(data, 112);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 144);
-contract MorphoSupplyHook is BaseMorphoLoanHook, ISuperHookInspector {
+contract MorphoSupplyHook is BaseMorphoLoanHook {
     using HookDataDecoder for bytes;
 
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/loan/morpho/MorphoSupplyHook.sol
+++ b/src/hooks/loan/morpho/MorphoSupplyHook.sol
@@ -97,7 +97,7 @@ contract MorphoSupplyHook is BaseMorphoLoanHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         SupplyHookLocalVars memory vars = _decodeSupplyHookData(data);
 
         MarketParams memory marketParams =

--- a/src/hooks/loan/morpho/MorphoSupplyHook.sol
+++ b/src/hooks/loan/morpho/MorphoSupplyHook.sol
@@ -10,10 +10,9 @@ import { IMorphoBase, MarketParams } from "../../../vendor/morpho/IMorpho.sol";
 // Superform
 import { BaseMorphoLoanHook } from "./BaseMorphoLoanHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
-import { ISuperHookLoans } from "../../../interfaces/ISuperHook.sol";
 import { ISuperHookResult } from "../../../interfaces/ISuperHook.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
-import { ISuperHook, ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
+import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 
 /// @title MorphoSupplyHook
 /// @author Superform Labs

--- a/src/hooks/loan/morpho/MorphoWithdrawHook.sol
+++ b/src/hooks/loan/morpho/MorphoWithdrawHook.sol
@@ -26,7 +26,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @notice         uint256 lltv = BytesLib.toUint256(data, 120);
 /// @notice         uint256 assets = BytesLib.toUint256(data, 152);
 /// @notice         uint256 shares = BytesLib.toUint256(data, 184);
-contract MorphoWithdrawHook is BaseMorphoLoanHook, ISuperHookInspector {
+contract MorphoWithdrawHook is BaseMorphoLoanHook {
     using MarketParamsLib for MarketParams;
     using HookDataDecoder for bytes;
 

--- a/src/hooks/loan/morpho/MorphoWithdrawHook.sol
+++ b/src/hooks/loan/morpho/MorphoWithdrawHook.sol
@@ -80,7 +80,7 @@ contract MorphoWithdrawHook is BaseMorphoLoanHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         WithdrawHookVars memory vars = _decodeWithdrawData(data);
 
         return abi.encodePacked(

--- a/src/hooks/stake/fluid/ApproveAndFluidStakeHook.sol
+++ b/src/hooks/stake/fluid/ApproveAndFluidStakeHook.sol
@@ -79,7 +79,7 @@ contract ApproveAndFluidStakeHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) //token

--- a/src/hooks/stake/fluid/ApproveAndFluidStakeHook.sol
+++ b/src/hooks/stake/fluid/ApproveAndFluidStakeHook.sol
@@ -21,7 +21,7 @@ import { ISuperHookContextAware, ISuperHookResult, ISuperHookInspector } from ".
 /// @notice         address token = BytesLib.toAddress(data, 52);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 72);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 104);
-contract ApproveAndFluidStakeHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract ApproveAndFluidStakeHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 72;

--- a/src/hooks/stake/fluid/FluidStakeHook.sol
+++ b/src/hooks/stake/fluid/FluidStakeHook.sol
@@ -19,7 +19,7 @@ import { ISuperHookContextAware, ISuperHookResult, ISuperHookInspector } from ".
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract FluidStakeHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract FluidStakeHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;

--- a/src/hooks/stake/fluid/FluidStakeHook.sol
+++ b/src/hooks/stake/fluid/FluidStakeHook.sol
@@ -70,7 +70,7 @@ contract FluidStakeHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/stake/fluid/FluidUnstakeHook.sol
+++ b/src/hooks/stake/fluid/FluidUnstakeHook.sol
@@ -72,7 +72,7 @@ contract FluidUnstakeHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/stake/fluid/FluidUnstakeHook.sol
+++ b/src/hooks/stake/fluid/FluidUnstakeHook.sol
@@ -21,7 +21,7 @@ import { IFluidLendingStakingRewards } from "../../../vendor/fluid/IFluidLending
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract FluidUnstakeHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract FluidUnstakeHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;

--- a/src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol
+++ b/src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol
@@ -80,7 +80,7 @@ contract ApproveAndGearboxStakeHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol
+++ b/src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol
@@ -21,7 +21,7 @@ import { IGearboxFarmingPool } from "../../../vendor/gearbox/IGearboxFarmingPool
 /// @notice         address token = BytesLib.toAddress(data, 52);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 72);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 104);
-contract ApproveAndGearboxStakeHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract ApproveAndGearboxStakeHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 72;

--- a/src/hooks/stake/gearbox/GearboxStakeHook.sol
+++ b/src/hooks/stake/gearbox/GearboxStakeHook.sol
@@ -70,7 +70,7 @@ contract GearboxStakeHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/stake/gearbox/GearboxStakeHook.sol
+++ b/src/hooks/stake/gearbox/GearboxStakeHook.sol
@@ -19,7 +19,7 @@ import { IGearboxFarmingPool } from "../../../vendor/gearbox/IGearboxFarmingPool
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract GearboxStakeHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract GearboxStakeHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;

--- a/src/hooks/stake/gearbox/GearboxUnstakeHook.sol
+++ b/src/hooks/stake/gearbox/GearboxUnstakeHook.sol
@@ -70,7 +70,7 @@ contract GearboxUnstakeHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/stake/gearbox/GearboxUnstakeHook.sol
+++ b/src/hooks/stake/gearbox/GearboxUnstakeHook.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 
 // Superform
@@ -13,7 +14,6 @@ import {
     ISuperHookResultOutflow, ISuperHookContextAware, ISuperHookInspector
 } from "../../../interfaces/ISuperHook.sol";
 import { IGearboxFarmingPool } from "../../../vendor/gearbox/IGearboxFarmingPool.sol";
-import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 /// @title GearboxUnstakeHook
 /// @author Superform Labs
@@ -22,7 +22,7 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract GearboxUnstakeHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract GearboxUnstakeHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;

--- a/src/hooks/swappers/1inch/Swap1InchHook.sol
+++ b/src/hooks/swappers/1inch/Swap1InchHook.sol
@@ -20,7 +20,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         uint256 value = BytesLib.toUint256(data, 40);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 72);
 /// @notice         bytes txData_ = BytesLib.slice(data, 73, data.length - 73);
-contract Swap1InchHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract Swap1InchHook is BaseHook, ISuperHookContextAware {
     using ProtocolLib for Address;
     using AddressLib for Address;
     using SafeCast for uint256;

--- a/src/hooks/swappers/1inch/Swap1InchHook.sol
+++ b/src/hooks/swappers/1inch/Swap1InchHook.sol
@@ -97,7 +97,7 @@ contract Swap1InchHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         bytes calldata txData_ = data[73:];
         bytes4 selector = bytes4(txData_[:4]);
 

--- a/src/hooks/swappers/odos/ApproveAndSwapOdosV2Hook.sol
+++ b/src/hooks/swappers/odos/ApproveAndSwapOdosV2Hook.sol
@@ -114,7 +114,7 @@ contract ApproveAndSwapOdosV2Hook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external view returns (bytes memory) {
+    function inspect(bytes calldata data) external view override returns (bytes memory) {
         uint256 pathDefinition_paramLength = BytesLib.toUint256(data, 157);
         address executor = BytesLib.toAddress(data, 189 + pathDefinition_paramLength);
 

--- a/src/hooks/swappers/odos/ApproveAndSwapOdosV2Hook.sol
+++ b/src/hooks/swappers/odos/ApproveAndSwapOdosV2Hook.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
-import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 import { IOdosRouterV2 } from "../../../vendor/odos/IOdosRouterV2.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
@@ -26,7 +26,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         bytes pathDefinition = BytesLib.slice(data, 189, pathDefinition_paramLength);
 /// @notice         address executor = BytesLib.toAddress(data, 189 + pathDefinition_paramLength);
 /// @notice         uint32 referralCode = BytesLib.toUint32(data, 189 + pathDefinition_paramLength + 20);
-contract ApproveAndSwapOdosV2Hook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract ApproveAndSwapOdosV2Hook is BaseHook, ISuperHookContextAware {
     IOdosRouterV2 public immutable odosRouterV2;
 
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 156;

--- a/src/hooks/swappers/odos/SwapOdosV2Hook.sol
+++ b/src/hooks/swappers/odos/SwapOdosV2Hook.sol
@@ -82,7 +82,7 @@ contract SwapOdosV2Hook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         uint256 pathDefinition_paramLength = BytesLib.toUint256(data, 157);
         address executor = BytesLib.toAddress(data, 189 + pathDefinition_paramLength);
 

--- a/src/hooks/swappers/odos/SwapOdosV2Hook.sol
+++ b/src/hooks/swappers/odos/SwapOdosV2Hook.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
-import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 import { IOdosRouterV2 } from "../../../vendor/odos/IOdosRouterV2.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
@@ -26,7 +26,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         bytes pathDefinition = BytesLib.slice(data, 189, pathDefinition_paramLength);
 /// @notice         address executor = BytesLib.toAddress(data, 189 + pathDefinition_paramLength);
 /// @notice         uint32 referralCode = BytesLib.toUint32(data, 189 + pathDefinition_paramLength + 20);
-contract SwapOdosV2Hook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract SwapOdosV2Hook is BaseHook, ISuperHookContextAware {
     IOdosRouterV2 public immutable odosRouterV2;
 
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 156;

--- a/src/hooks/swappers/pendle/PendleRouterRedeemHook.sol
+++ b/src/hooks/swappers/pendle/PendleRouterRedeemHook.sol
@@ -12,7 +12,6 @@ import { BaseHook } from "../../BaseHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 import {
-    ISuperHook,
     ISuperHookResult,
     ISuperHookContextAware,
     ISuperHookInspector
@@ -28,7 +27,7 @@ import {
 /// @notice         uint256 minTokenOut = BytesLib.toUint256(data, 92);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 124);
 /// @notice         bytes output = BytesLib.slice(data, 125, data.length - 125);
-contract PendleRouterRedeemHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract PendleRouterRedeemHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     // Offset for bool usePrevHookAmount (after packed amount, YT, tokenOut, minTokenOut)

--- a/src/hooks/swappers/pendle/PendleRouterRedeemHook.sol
+++ b/src/hooks/swappers/pendle/PendleRouterRedeemHook.sol
@@ -11,11 +11,7 @@ import { BytesLib } from "../../../vendor/BytesLib.sol";
 import { BaseHook } from "../../BaseHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
-import {
-    ISuperHookResult,
-    ISuperHookContextAware,
-    ISuperHookInspector
-} from "../../../interfaces/ISuperHook.sol";
+import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 
 /// @title PendleRouterRedeemHook
 /// @author Superform Labs
@@ -118,7 +114,7 @@ contract PendleRouterRedeemHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         DecodedParams memory params = _decodeAndValidateData(data);
         return abi.encodePacked(params.YT, params.PT, params.tokenOut);
     }

--- a/src/hooks/swappers/pendle/PendleRouterSwapHook.sol
+++ b/src/hooks/swappers/pendle/PendleRouterSwapHook.sol
@@ -96,7 +96,7 @@ contract PendleRouterSwapHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         bytes calldata txData_ = data[85:];
         bytes4 selector = bytes4(txData_[0:4]);
 

--- a/src/hooks/swappers/pendle/PendleRouterSwapHook.sol
+++ b/src/hooks/swappers/pendle/PendleRouterSwapHook.sol
@@ -8,12 +8,7 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
-import {
-    ISuperHook,
-    ISuperHookResult,
-    ISuperHookContextAware,
-    ISuperHookInspector
-} from "../../../interfaces/ISuperHook.sol";
+import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 import {
     IPendleRouterV4,
     ApproxParams,
@@ -35,7 +30,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 52);
 /// @notice         uint256 value = BytesLib.toUint256(data, 53);
 /// @notice         bytes txData_ = BytesLib.slice(data, 85, data.length - 85);
-contract PendleRouterSwapHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract PendleRouterSwapHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 52;

--- a/src/hooks/swappers/spectra/SpectraExchangeDepositHook.sol
+++ b/src/hooks/swappers/spectra/SpectraExchangeDepositHook.sol
@@ -90,7 +90,7 @@ contract SpectraExchangeDepositHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         bytes calldata txData_ = data[TX_DATA_POSITION:];
         ValidateTxDataParams memory params;
         params.selector = bytes4(txData_[0:4]);

--- a/src/hooks/swappers/spectra/SpectraExchangeDepositHook.sol
+++ b/src/hooks/swappers/spectra/SpectraExchangeDepositHook.sol
@@ -22,7 +22,7 @@ import { SpectraCommands } from "../../../vendor/spectra/SpectraCommands.sol";
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 52);
 /// @notice         uint256 value = BytesLib.toUint256(data, 53);
 /// @notice         bytes txData_ = BytesLib.slice(data, 85, data.length - 85);
-contract SpectraExchangeDepositHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract SpectraExchangeDepositHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 52;

--- a/src/hooks/swappers/spectra/SpectraExchangeRedeemHook.sol
+++ b/src/hooks/swappers/spectra/SpectraExchangeRedeemHook.sol
@@ -24,7 +24,7 @@ import { SpectraCommands } from "../../../vendor/spectra/SpectraCommands.sol";
 /// @notice         uint256 sharesToBurn = BytesLib.toUint256(data, 124);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 156);
 /// @notice         bytes1 command = BytesLib.slice(data, 157, 1);
-contract SpectraExchangeRedeemHook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract SpectraExchangeRedeemHook is BaseHook, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 156;

--- a/src/hooks/swappers/spectra/SpectraExchangeRedeemHook.sol
+++ b/src/hooks/swappers/spectra/SpectraExchangeRedeemHook.sol
@@ -119,7 +119,7 @@ contract SpectraExchangeRedeemHook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         RedeemParams memory params = _decodeRedeemParams(data);
 
         return abi.encodePacked(params.asset, params.pt, params.recipient);

--- a/src/hooks/tokens/BatchTransferHook.sol
+++ b/src/hooks/tokens/BatchTransferHook.sol
@@ -18,7 +18,7 @@ address constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 /// @dev data has the following structure
 /// @notice         address to = BytesLib.toAddress(data, 0);
 /// @notice         bytes tokensArr = BytesLib.slice(data, 20, data.length - 20);
-contract BatchTransferHook is BaseHook, ISuperHookInspector {
+contract BatchTransferHook is BaseHook {
     error LENGTH_MISMATCH();
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.TOKEN) { }

--- a/src/hooks/tokens/BatchTransferHook.sol
+++ b/src/hooks/tokens/BatchTransferHook.sol
@@ -65,7 +65,7 @@ contract BatchTransferHook is BaseHook {
                                  EXTERNAL METHODS
     //////////////////////////////////////////////////////////////*/
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         // First 20 bytes is the 'to' address
         address to = BytesLib.toAddress(data, 0);
 

--- a/src/hooks/tokens/OfframpTokensHook.sol
+++ b/src/hooks/tokens/OfframpTokensHook.sol
@@ -66,7 +66,7 @@ contract OfframpTokensHook is BaseHook {
                                  EXTERNAL METHODS
     //////////////////////////////////////////////////////////////*/
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         // First 20 bytes is the 'to' address
         address to = BytesLib.toAddress(data, 0);
 

--- a/src/hooks/tokens/OfframpTokensHook.sol
+++ b/src/hooks/tokens/OfframpTokensHook.sol
@@ -18,7 +18,7 @@ address constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 /// @dev data has the following structure
 /// @notice         address to = BytesLib.toAddress(data, 0);
 /// @notice         bytes tokensArr = BytesLib.slice(data, 20, data.length - 20);
-contract OfframpTokensHook is BaseHook, ISuperHookInspector {
+contract OfframpTokensHook is BaseHook {
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 52;
 
     error LENGTH_MISMATCH();

--- a/src/hooks/tokens/erc20/ApproveERC20Hook.sol
+++ b/src/hooks/tokens/erc20/ApproveERC20Hook.sol
@@ -67,7 +67,7 @@ contract ApproveERC20Hook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             BytesLib.toAddress(data, 0), //token
             BytesLib.toAddress(data, 20) //spender

--- a/src/hooks/tokens/erc20/ApproveERC20Hook.sol
+++ b/src/hooks/tokens/erc20/ApproveERC20Hook.sol
@@ -3,9 +3,8 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
-import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
-
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
@@ -20,7 +19,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         address spender = BytesLib.toAddress(data, 20);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 40);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 72);
-contract ApproveERC20Hook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract ApproveERC20Hook is BaseHook, ISuperHookContextAware {
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 72;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.TOKEN) { }

--- a/src/hooks/tokens/erc20/TransferERC20Hook.sol
+++ b/src/hooks/tokens/erc20/TransferERC20Hook.sol
@@ -18,7 +18,7 @@ import { ISuperHookResult, ISuperHookContextAware, ISuperHookInspector } from ".
 /// @notice         address to = BytesLib.toAddress(data, 20);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 40);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 72);
-contract TransferERC20Hook is BaseHook, ISuperHookContextAware, ISuperHookInspector {
+contract TransferERC20Hook is BaseHook, ISuperHookContextAware {
     uint256 private constant USE_PREV_HOOK_AMOUNT_POSITION = 72;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.TOKEN) { }

--- a/src/hooks/tokens/erc20/TransferERC20Hook.sol
+++ b/src/hooks/tokens/erc20/TransferERC20Hook.sol
@@ -64,7 +64,7 @@ contract TransferERC20Hook is BaseHook, ISuperHookContextAware {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             BytesLib.toAddress(data, 0), //token
             BytesLib.toAddress(data, 20) //to

--- a/src/hooks/tokens/permit2/BatchTransferFromHook.sol
+++ b/src/hooks/tokens/permit2/BatchTransferFromHook.sol
@@ -26,7 +26,7 @@ import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 /// @notice     bytes nonces = BytesLib.slice(data, 84 + 20 * tokensLength + 32 * tokensLength, 48 * tokensLength);
 /// @notice     bytes signature = BytesLib.slice(data, 84 + 20 * tokensLength + 32 * tokensLength + 48 * tokensLength,
 /// 65);
-contract BatchTransferFromHook is BaseHook, ISuperHookInspector {
+contract BatchTransferFromHook is BaseHook {
     using SafeCast for uint256;
 
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/tokens/permit2/BatchTransferFromHook.sol
+++ b/src/hooks/tokens/permit2/BatchTransferFromHook.sol
@@ -144,7 +144,7 @@ contract BatchTransferFromHook is BaseHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         uint256 tokensLength = BytesLib.toUint256(data, 20);
         bytes memory tokensData = BytesLib.slice(data, 84, 20 * tokensLength);
         address[] memory tokens = new address[](tokensLength);

--- a/src/hooks/vaults/4626/ApproveAndDeposit4626VaultHook.sol
+++ b/src/hooks/vaults/4626/ApproveAndDeposit4626VaultHook.sol
@@ -32,8 +32,7 @@ contract ApproveAndDeposit4626VaultHook is
     BaseHook,
     VaultBankLockableHook,
     ISuperHookInflowOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/4626/ApproveAndDeposit4626VaultHook.sol
+++ b/src/hooks/vaults/4626/ApproveAndDeposit4626VaultHook.sol
@@ -93,7 +93,7 @@ contract ApproveAndDeposit4626VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) //token

--- a/src/hooks/vaults/4626/Deposit4626VaultHook.sol
+++ b/src/hooks/vaults/4626/Deposit4626VaultHook.sol
@@ -25,12 +25,7 @@ import {
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract Deposit4626VaultHook is
-    BaseHook,
-    VaultBankLockableHook,
-    ISuperHookInflowOutflow,
-    ISuperHookContextAware
-{
+contract Deposit4626VaultHook is BaseHook, VaultBankLockableHook, ISuperHookInflowOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;
@@ -83,7 +78,7 @@ contract Deposit4626VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/4626/Deposit4626VaultHook.sol
+++ b/src/hooks/vaults/4626/Deposit4626VaultHook.sol
@@ -8,8 +8,8 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
-import { VaultBankLockableHook } from "../../VaultBankLockableHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
+import { VaultBankLockableHook } from "../../VaultBankLockableHook.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 import {
     ISuperHookResult,
@@ -29,8 +29,7 @@ contract Deposit4626VaultHook is
     BaseHook,
     VaultBankLockableHook,
     ISuperHookInflowOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/4626/Redeem4626VaultHook.sol
+++ b/src/hooks/vaults/4626/Redeem4626VaultHook.sol
@@ -31,8 +31,7 @@ contract Redeem4626VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/4626/Redeem4626VaultHook.sol
+++ b/src/hooks/vaults/4626/Redeem4626VaultHook.sol
@@ -27,12 +27,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         address owner = BytesLib.toAddress(data, 52);
 /// @notice         uint256 shares = BytesLib.toUint256(data, 72);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 104);
-contract Redeem4626VaultHook is
-    BaseHook,
-    ISuperHookInflowOutflow,
-    ISuperHookOutflow,
-    ISuperHookContextAware
-{
+contract Redeem4626VaultHook is BaseHook, ISuperHookInflowOutflow, ISuperHookOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 72;
@@ -94,7 +89,7 @@ contract Redeem4626VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) // owner

--- a/src/hooks/vaults/5115/ApproveAndDeposit5115VaultHook.sol
+++ b/src/hooks/vaults/5115/ApproveAndDeposit5115VaultHook.sol
@@ -99,7 +99,7 @@ contract ApproveAndDeposit5115VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) // tokenIn

--- a/src/hooks/vaults/5115/ApproveAndDeposit5115VaultHook.sol
+++ b/src/hooks/vaults/5115/ApproveAndDeposit5115VaultHook.sol
@@ -34,8 +34,7 @@ contract ApproveAndDeposit5115VaultHook is
     BaseHook,
     VaultBankLockableHook,
     ISuperHookInflowOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/5115/Deposit5115VaultHook.sol
+++ b/src/hooks/vaults/5115/Deposit5115VaultHook.sol
@@ -28,12 +28,7 @@ import {
 /// @notice         uint256 amount = BytesLib.toUint256(data, 72);
 /// @notice         uint256 minSharesOut = BytesLib.toUint256(data, 104);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 136);
-contract Deposit5115VaultHook is
-    BaseHook,
-    VaultBankLockableHook,
-    ISuperHookInflowOutflow,
-    ISuperHookContextAware
-{
+contract Deposit5115VaultHook is BaseHook, VaultBankLockableHook, ISuperHookInflowOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 72;
@@ -91,7 +86,7 @@ contract Deposit5115VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) // tokenIn

--- a/src/hooks/vaults/5115/Deposit5115VaultHook.sol
+++ b/src/hooks/vaults/5115/Deposit5115VaultHook.sol
@@ -32,8 +32,7 @@ contract Deposit5115VaultHook is
     BaseHook,
     VaultBankLockableHook,
     ISuperHookInflowOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/5115/Redeem5115VaultHook.sol
+++ b/src/hooks/vaults/5115/Redeem5115VaultHook.sol
@@ -28,12 +28,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         uint256 shares = BytesLib.toUint256(data, 72);
 /// @notice         uint256 minTokenOut = BytesLib.toUint256(data, 104);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 136);
-contract Redeem5115VaultHook is
-    BaseHook,
-    ISuperHookInflowOutflow,
-    ISuperHookOutflow,
-    ISuperHookContextAware
-{
+contract Redeem5115VaultHook is BaseHook, ISuperHookInflowOutflow, ISuperHookOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 72;
@@ -96,7 +91,7 @@ contract Redeem5115VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) // tokenOut

--- a/src/hooks/vaults/5115/Redeem5115VaultHook.sol
+++ b/src/hooks/vaults/5115/Redeem5115VaultHook.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 import { IStandardizedYield } from "../../../vendor/pendle/IStandardizedYield.sol";
 
 // Superform
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { BaseHook } from "../../BaseHook.sol";
 import {
     ISuperHookResultOutflow,
@@ -32,8 +32,7 @@ contract Redeem5115VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/ApproveAndRequestDeposit7540VaultHook.sol
+++ b/src/hooks/vaults/7540/ApproveAndRequestDeposit7540VaultHook.sol
@@ -32,8 +32,7 @@ contract ApproveAndRequestDeposit7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookAsyncCancelations,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/ApproveAndRequestDeposit7540VaultHook.sol
+++ b/src/hooks/vaults/7540/ApproveAndRequestDeposit7540VaultHook.sol
@@ -101,7 +101,7 @@ contract ApproveAndRequestDeposit7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) //token

--- a/src/hooks/vaults/7540/ApproveAndRequestRedeem7540VaultHook.sol
+++ b/src/hooks/vaults/7540/ApproveAndRequestRedeem7540VaultHook.sol
@@ -31,8 +31,7 @@ contract ApproveAndRequestRedeem7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/ApproveAndRequestRedeem7540VaultHook.sol
+++ b/src/hooks/vaults/7540/ApproveAndRequestRedeem7540VaultHook.sol
@@ -100,7 +100,7 @@ contract ApproveAndRequestRedeem7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) //token

--- a/src/hooks/vaults/7540/CancelDepositRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/CancelDepositRequest7540Hook.sol
@@ -48,7 +48,7 @@ contract CancelDepositRequest7540Hook is BaseHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/7540/CancelDepositRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/CancelDepositRequest7540Hook.sol
@@ -16,7 +16,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @dev data has the following structure
 /// @notice         bytes32 placeholder = bytes32(BytesLib.slice(data, 0, 32), 0);
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
-contract CancelDepositRequest7540Hook is BaseHook, ISuperHookInspector {
+contract CancelDepositRequest7540Hook is BaseHook {
     using HookDataDecoder for bytes;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.CANCEL_DEPOSIT_REQUEST) { }

--- a/src/hooks/vaults/7540/CancelRedeemRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/CancelRedeemRequest7540Hook.sol
@@ -48,7 +48,7 @@ contract CancelRedeemRequest7540Hook is BaseHook {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
     /*//////////////////////////////////////////////////////////////

--- a/src/hooks/vaults/7540/CancelRedeemRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/CancelRedeemRequest7540Hook.sol
@@ -16,7 +16,7 @@ import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 /// @dev data has the following structure
 /// @notice         bytes32 placeholder = bytes32(BytesLib.slice(data, 0, 32), 0);
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
-contract CancelRedeemRequest7540Hook is BaseHook, ISuperHookInspector {
+contract CancelRedeemRequest7540Hook is BaseHook {
     using HookDataDecoder for bytes;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.CANCEL_REDEEM_REQUEST) { }

--- a/src/hooks/vaults/7540/ClaimCancelDepositRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/ClaimCancelDepositRequest7540Hook.sol
@@ -62,7 +62,7 @@ contract ClaimCancelDepositRequest7540Hook is BaseHook, ISuperHookAsyncCancelati
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) //receiver

--- a/src/hooks/vaults/7540/ClaimCancelDepositRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/ClaimCancelDepositRequest7540Hook.sol
@@ -20,7 +20,7 @@ import { ISuperHookAsyncCancelations, ISuperHookInspector } from "../../../inter
 /// @notice         bytes32 placeholder = bytes32(BytesLib.slice(data, 0, 32), 0);
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         address receiver = BytesLib.toAddress(data, 52);
-contract ClaimCancelDepositRequest7540Hook is BaseHook, ISuperHookAsyncCancelations, ISuperHookInspector {
+contract ClaimCancelDepositRequest7540Hook is BaseHook, ISuperHookAsyncCancelations {
     using HookDataDecoder for bytes;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.CLAIM_CANCEL_DEPOSIT_REQUEST) { }

--- a/src/hooks/vaults/7540/ClaimCancelRedeemRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/ClaimCancelRedeemRequest7540Hook.sol
@@ -21,11 +21,7 @@ import { ISuperHookAsyncCancelations, ISuperHookInspector } from "../../../inter
 /// @notice         bytes32 placeholder = bytes32(BytesLib.slice(data, 0, 32), 0);
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         address receiver = BytesLib.toAddress(data, 52);
-contract ClaimCancelRedeemRequest7540Hook is
-    BaseHook,
-    VaultBankLockableHook,
-    ISuperHookAsyncCancelations
-{
+contract ClaimCancelRedeemRequest7540Hook is BaseHook, VaultBankLockableHook, ISuperHookAsyncCancelations {
     using HookDataDecoder for bytes;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.CLAIM_CANCEL_REDEEM_REQUEST) { }
@@ -67,7 +63,7 @@ contract ClaimCancelRedeemRequest7540Hook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             BytesLib.toAddress(data, 52) //receiver

--- a/src/hooks/vaults/7540/ClaimCancelRedeemRequest7540Hook.sol
+++ b/src/hooks/vaults/7540/ClaimCancelRedeemRequest7540Hook.sol
@@ -3,10 +3,11 @@ pragma solidity 0.8.30;
 
 // external
 import { BytesLib } from "../../../vendor/BytesLib.sol";
-import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
-import { IERC7540CancelRedeem } from "../../../vendor/standards/ERC7540/IERC7540Vault.sol";
 import { IERC7540 } from "../../../vendor/vaults/7540/IERC7540.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
+import { IERC7540CancelRedeem } from "../../../vendor/standards/ERC7540/IERC7540Vault.sol";
+
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
 import { VaultBankLockableHook } from "../../VaultBankLockableHook.sol";
@@ -23,8 +24,7 @@ import { ISuperHookAsyncCancelations, ISuperHookInspector } from "../../../inter
 contract ClaimCancelRedeemRequest7540Hook is
     BaseHook,
     VaultBankLockableHook,
-    ISuperHookAsyncCancelations,
-    ISuperHookInspector
+    ISuperHookAsyncCancelations
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/Deposit7540VaultHook.sol
+++ b/src/hooks/vaults/7540/Deposit7540VaultHook.sol
@@ -6,12 +6,12 @@ import { BytesLib } from "../../../vendor/BytesLib.sol";
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 import { IERC7540 } from "../../../vendor/vaults/7540/IERC7540.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
 import { VaultBankLockableHook } from "../../VaultBankLockableHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
-
 import {
     ISuperHookResult,
     ISuperHookInflowOutflow,
@@ -30,8 +30,7 @@ contract Deposit7540VaultHook is
     BaseHook,
     VaultBankLockableHook,
     ISuperHookInflowOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/Deposit7540VaultHook.sol
+++ b/src/hooks/vaults/7540/Deposit7540VaultHook.sol
@@ -26,12 +26,7 @@ import {
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract Deposit7540VaultHook is
-    BaseHook,
-    VaultBankLockableHook,
-    ISuperHookInflowOutflow,
-    ISuperHookContextAware
-{
+contract Deposit7540VaultHook is BaseHook, VaultBankLockableHook, ISuperHookInflowOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;
@@ -87,7 +82,7 @@ contract Deposit7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/7540/Redeem7540VaultHook.sol
+++ b/src/hooks/vaults/7540/Redeem7540VaultHook.sol
@@ -27,12 +27,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 shares = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract Redeem7540VaultHook is
-    BaseHook,
-    ISuperHookInflowOutflow,
-    ISuperHookOutflow,
-    ISuperHookContextAware
-{
+contract Redeem7540VaultHook is BaseHook, ISuperHookInflowOutflow, ISuperHookOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;
@@ -92,7 +87,7 @@ contract Redeem7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/7540/Redeem7540VaultHook.sol
+++ b/src/hooks/vaults/7540/Redeem7540VaultHook.sol
@@ -31,8 +31,7 @@ contract Redeem7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/RequestDeposit7540VaultHook.sol
+++ b/src/hooks/vaults/7540/RequestDeposit7540VaultHook.sol
@@ -30,8 +30,7 @@ contract RequestDeposit7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookAsyncCancelations,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/RequestDeposit7540VaultHook.sol
+++ b/src/hooks/vaults/7540/RequestDeposit7540VaultHook.sol
@@ -92,7 +92,7 @@ contract RequestDeposit7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/7540/RequestRedeem7540VaultHook.sol
+++ b/src/hooks/vaults/7540/RequestRedeem7540VaultHook.sol
@@ -93,7 +93,7 @@ contract RequestRedeem7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/7540/RequestRedeem7540VaultHook.sol
+++ b/src/hooks/vaults/7540/RequestRedeem7540VaultHook.sol
@@ -31,8 +31,7 @@ contract RequestRedeem7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookAsyncCancelations,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/Withdraw7540VaultHook.sol
+++ b/src/hooks/vaults/7540/Withdraw7540VaultHook.sol
@@ -31,8 +31,7 @@ contract Withdraw7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/7540/Withdraw7540VaultHook.sol
+++ b/src/hooks/vaults/7540/Withdraw7540VaultHook.sol
@@ -27,12 +27,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract Withdraw7540VaultHook is
-    BaseHook,
-    ISuperHookInflowOutflow,
-    ISuperHookOutflow,
-    ISuperHookContextAware
-{
+contract Withdraw7540VaultHook is BaseHook, ISuperHookInflowOutflow, ISuperHookOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;
@@ -93,7 +88,7 @@ contract Withdraw7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/ethena/EthenaCooldownSharesHook.sol
+++ b/src/hooks/vaults/ethena/EthenaCooldownSharesHook.sol
@@ -9,9 +9,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IStakedUSDeCooldown } from "../../../vendor/ethena/IStakedUSDeCooldown.sol";
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
-import { ISuperHookResult, ISuperHookInflowOutflow, ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
+import { ISuperHookResult, ISuperHookInflowOutflow, ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 
 /// @title EthenaCooldownSharesHook
 /// @author Superform Labs
@@ -21,7 +21,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 shares = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract EthenaCooldownSharesHook is BaseHook, ISuperHookInflowOutflow, ISuperHookInspector {
+contract EthenaCooldownSharesHook is BaseHook, ISuperHookInflowOutflow {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;

--- a/src/hooks/vaults/ethena/EthenaCooldownSharesHook.sol
+++ b/src/hooks/vaults/ethena/EthenaCooldownSharesHook.sol
@@ -63,7 +63,7 @@ contract EthenaCooldownSharesHook is BaseHook, ISuperHookInflowOutflow {
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/ethena/EthenaUnstakeHook.sol
+++ b/src/hooks/vaults/ethena/EthenaUnstakeHook.sol
@@ -57,7 +57,7 @@ contract EthenaUnstakeHook is BaseHook {
     //////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/ethena/EthenaUnstakeHook.sol
+++ b/src/hooks/vaults/ethena/EthenaUnstakeHook.sol
@@ -10,8 +10,8 @@ import { IStakedUSDeCooldown } from "../../../vendor/ethena/IStakedUSDeCooldown.
 
 // Superform
 import { BaseHook } from "../../BaseHook.sol";
-import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
+import { ISuperHookInspector } from "../../../interfaces/ISuperHook.sol";
 import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 
 /// @title EthenaUnstakeHook
@@ -19,7 +19,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @dev data has the following structure
 /// @notice         bytes32 yieldSourceOracleId = bytes32(BytesLib.slice(data, 0, 32), 0);
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
-contract EthenaUnstakeHook is BaseHook, ISuperHookInspector {
+contract EthenaUnstakeHook is BaseHook {
     using HookDataDecoder for bytes;
 
     constructor() BaseHook(HookType.OUTFLOW, HookSubTypes.ETHENA) { }

--- a/src/hooks/vaults/super-vault/CancelRedeemHook.sol
+++ b/src/hooks/vaults/super-vault/CancelRedeemHook.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.30;
 
 // external
-import { BytesLib } from "../../../vendor/BytesLib.sol";
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 import { IERC7540 } from "../../../vendor/vaults/7540/IERC7540.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -20,7 +19,7 @@ import { ISuperHookAsyncCancelations, ISuperHookInspector } from "../../../inter
 /// @dev data has the following structure
 /// @notice         bytes32 placeholder = bytes32(BytesLib.slice(data, 0, 32), 0);
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
-contract CancelRedeemHook is BaseHook, VaultBankLockableHook, ISuperHookAsyncCancelations, ISuperHookInspector {
+contract CancelRedeemHook is BaseHook, VaultBankLockableHook, ISuperHookAsyncCancelations {
     using HookDataDecoder for bytes;
 
     constructor() BaseHook(HookType.NONACCOUNTING, HookSubTypes.CANCEL_REDEEM) { }

--- a/src/hooks/vaults/super-vault/CancelRedeemHook.sol
+++ b/src/hooks/vaults/super-vault/CancelRedeemHook.sol
@@ -56,7 +56,7 @@ contract CancelRedeemHook is BaseHook, VaultBankLockableHook, ISuperHookAsyncCan
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/super-vault/Withdraw7540VaultHook.sol
+++ b/src/hooks/vaults/super-vault/Withdraw7540VaultHook.sol
@@ -31,8 +31,7 @@ contract Withdraw7540VaultHook is
     BaseHook,
     ISuperHookInflowOutflow,
     ISuperHookOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using HookDataDecoder for bytes;
 

--- a/src/hooks/vaults/super-vault/Withdraw7540VaultHook.sol
+++ b/src/hooks/vaults/super-vault/Withdraw7540VaultHook.sol
@@ -27,12 +27,7 @@ import { HookDataDecoder } from "../../../libraries/HookDataDecoder.sol";
 /// @notice         address yieldSource = BytesLib.toAddress(data, 32);
 /// @notice         uint256 amount = BytesLib.toUint256(data, 52);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 84);
-contract Withdraw7540VaultHook is
-    BaseHook,
-    ISuperHookInflowOutflow,
-    ISuperHookOutflow,
-    ISuperHookContextAware
-{
+contract Withdraw7540VaultHook is BaseHook, ISuperHookInflowOutflow, ISuperHookOutflow, ISuperHookContextAware {
     using HookDataDecoder for bytes;
 
     uint256 private constant AMOUNT_POSITION = 52;
@@ -93,7 +88,7 @@ contract Withdraw7540VaultHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(data.extractYieldSource());
     }
 

--- a/src/hooks/vaults/vault-bank/MintSuperPositionsHook.sol
+++ b/src/hooks/vaults/vault-bank/MintSuperPositionsHook.sol
@@ -36,8 +36,7 @@ contract MintSuperPositionsHook is
     BaseHook,
     VaultBankLockableHook,
     ISuperHookInflowOutflow,
-    ISuperHookContextAware,
-    ISuperHookInspector
+    ISuperHookContextAware
 {
     using SafeCast for uint256;
     using HookDataDecoder for bytes;

--- a/src/hooks/vaults/vault-bank/MintSuperPositionsHook.sol
+++ b/src/hooks/vaults/vault-bank/MintSuperPositionsHook.sol
@@ -32,12 +32,7 @@ import {
 ///         bool usePrevHookAmount = BytesLib.toBool(data, 84);
 ///         address vaultBank = BytesLib.toAddress(data, 85);
 ///         uint256 dstChainId = BytesLib.toUint256(data, 105);
-contract MintSuperPositionsHook is
-    BaseHook,
-    VaultBankLockableHook,
-    ISuperHookInflowOutflow,
-    ISuperHookContextAware
-{
+contract MintSuperPositionsHook is BaseHook, VaultBankLockableHook, ISuperHookInflowOutflow, ISuperHookContextAware {
     using SafeCast for uint256;
     using HookDataDecoder for bytes;
 
@@ -114,7 +109,7 @@ contract MintSuperPositionsHook is
     }
 
     /// @inheritdoc ISuperHookInspector
-    function inspect(bytes calldata data) external pure returns (bytes memory) {
+    function inspect(bytes calldata data) external pure override returns (bytes memory) {
         return abi.encodePacked(
             data.extractYieldSource(),
             /**


### PR DESCRIPTION
Adds virtual `inspect()` function to `BaseHook` which is then overridden in each hook.
Removes inheritance of `ISuperHookInspector` in hooks as they now have access to `inspect()` via `BaseHook`  which inherits `ISuperHookInspector`