### PR TITLE
feat: sup 12845 fix issue 64 in periphery audit

### DIFF
--- a/src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol
+++ b/src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol
@@ -81,7 +81,10 @@ contract ApproveAndGearboxStakeHook is BaseHook, ISuperHookContextAware, ISuperH
 
     /// @inheritdoc ISuperHookInspector
     function inspect(bytes calldata data) external pure returns (bytes memory) {
-        return abi.encodePacked(data.extractYieldSource());
+        return abi.encodePacked(
+            data.extractYieldSource(),
+            BytesLib.toAddress(data, 52) // token
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/unit/hooks/claim/fluid/FluidClaimRewardHook.t.sol
+++ b/test/unit/hooks/claim/fluid/FluidClaimRewardHook.t.sol
@@ -8,8 +8,11 @@ import { IFluidLendingStakingRewards } from "../../../../../src/vendor/fluid/IFl
 import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract FluidClaimRewardHookTest is Helpers {
+    using BytesLib for bytes;
+
     FluidClaimRewardHook public hook;
     address public stakingRewards;
     address public rewardToken;
@@ -86,6 +89,9 @@ contract FluidClaimRewardHookTest is Helpers {
         bytes memory data = _encodeData();
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), stakingRewards);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), rewardToken);
     }
 
     function test_CalldataDecoding() public view {

--- a/test/unit/hooks/claim/gearbox/GearboxClaimRewardHook.t.sol
+++ b/test/unit/hooks/claim/gearbox/GearboxClaimRewardHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
 import { IGearboxFarmingPool } from "../../../../../src/vendor/gearbox/IGearboxFarmingPool.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract GearboxClaimRewardHookTest is Helpers {
+    using BytesLib for bytes;
+    
     GearboxClaimRewardHook public hook;
     address public mockFarmingPool;
     address public mockRewardToken;
@@ -86,6 +89,9 @@ contract GearboxClaimRewardHookTest is Helpers {
         bytes memory data = _encodeData();
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), mockFarmingPool);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), mockRewardToken);
     }
 
     function test_CalldataDecoding() public view {

--- a/test/unit/hooks/claim/yearn/YearnClaimRewardHook.t.sol
+++ b/test/unit/hooks/claim/yearn/YearnClaimRewardHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
 import { IYearnStakingRewardsMulti } from "../../../../../src/vendor/yearn/IYearnStakingRewardsMulti.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract YearnClaimOneRewardHookTest is Helpers {
+    using BytesLib for bytes;
+
     YearnClaimOneRewardHook public hook;
     address public mockYieldSource;
     address public mockRewardToken;
@@ -80,6 +83,9 @@ contract YearnClaimOneRewardHookTest is Helpers {
         bytes memory data = _encodeData();
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), mockYieldSource);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), mockRewardToken);
     }
 
     function test_CalldataDecoding() public view {

--- a/test/unit/hooks/stake/fluid/ApproveAndFluidStakeHook.t.sol
+++ b/test/unit/hooks/stake/fluid/ApproveAndFluidStakeHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract ApproveAndFluidStakeHookTest is Helpers {
+    using BytesLib for bytes;
+
     ApproveAndFluidStakeHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -43,7 +46,11 @@ contract ApproveAndFluidStakeHookTest is Helpers {
     function test_Inspector() public view {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
+
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), token);
     }
 
     function test_Build() public view {

--- a/test/unit/hooks/stake/fluid/FluidStakeHook.t.sol
+++ b/test/unit/hooks/stake/fluid/FluidStakeHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract FluidStakeHookTest is Helpers {
+    using BytesLib for bytes;
+
     FluidStakeHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -36,6 +39,8 @@ contract FluidStakeHookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
     }
 
     function test_DecodeUsePrevHookAmount() public view {

--- a/test/unit/hooks/stake/fluid/FluidUnstakeHook.t.sol
+++ b/test/unit/hooks/stake/fluid/FluidUnstakeHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract FluidUnstakeHookTest is Helpers {
+    using BytesLib for bytes;
+
     FluidUnstakeHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -36,6 +39,8 @@ contract FluidUnstakeHookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
     }
 
     function test_DecodeUsePrevHookAmount() public view {

--- a/test/unit/hooks/stake/gearbox/ApproveAndGearboxStakeHook.t.sol
+++ b/test/unit/hooks/stake/gearbox/ApproveAndGearboxStakeHook.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.30;
 
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 import { ApproveAndGearboxStakeHook } from "../../../../../src/hooks/stake/gearbox/ApproveAndGearboxStakeHook.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 import { ISuperHook } from "../../../../../src/interfaces/ISuperHook.sol";
 import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
@@ -10,6 +11,8 @@ import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
 
 contract ApproveAndGearboxStakeHookTest is Helpers {
+    using BytesLib for bytes;
+
     ApproveAndGearboxStakeHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -80,6 +83,10 @@ contract ApproveAndGearboxStakeHookTest is Helpers {
     function test_Inspector() public view {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
+        
+        assertEq(yieldSource, BytesLib.toAddress(argsEncoded, 0));
+        assertEq(token, BytesLib.toAddress(argsEncoded, 20));
+
         assertGt(argsEncoded.length, 0);
     }
 

--- a/test/unit/hooks/stake/gearbox/GearboxStakeHook.t.sol
+++ b/test/unit/hooks/stake/gearbox/GearboxStakeHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract GearboxStakeHookTest is Helpers {
+    using BytesLib for bytes;
+
     GearboxStakeHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -35,7 +38,10 @@ contract GearboxStakeHookTest is Helpers {
     function test_Inspector() public view {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
+
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
     }
 
     function test_Build() public view {

--- a/test/unit/hooks/stake/gearbox/GearboxUnstakeHook.t.sol
+++ b/test/unit/hooks/stake/gearbox/GearboxUnstakeHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract GearboxUnstakeHookTest is Helpers {
+    using BytesLib for bytes;
+
     GearboxUnstakeHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -36,6 +39,8 @@ contract GearboxUnstakeHookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
     }
 
     function test_DecodeUsePrevHookAmount() public view {

--- a/test/unit/hooks/tokens/BatchTransferHook.t.sol
+++ b/test/unit/hooks/tokens/BatchTransferHook.t.sol
@@ -9,8 +9,11 @@ import { MockERC20 } from "../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract BatchTransferHookTest is Helpers {
+    using BytesLib for bytes;
+    
     BatchTransferHook public hook;
 
     address token1;

--- a/test/unit/hooks/tokens/erc20/ApproveERC20Hook.t.sol
+++ b/test/unit/hooks/tokens/erc20/ApproveERC20Hook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract ApproveERC20HookTest is Helpers {
+    using BytesLib for bytes;
+
     ApproveERC20Hook public hook;
 
     address token;
@@ -99,6 +102,9 @@ contract ApproveERC20HookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), token);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), spender);
     }
 
     function _encodeData(bool usePrev) internal view returns (bytes memory) {

--- a/test/unit/hooks/tokens/erc20/TransferERC20Hook.t.sol
+++ b/test/unit/hooks/tokens/erc20/TransferERC20Hook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract TransferERC20HookTest is Helpers {
+    using BytesLib for bytes;
+
     TransferERC20Hook public hook;
 
     address token;
@@ -85,6 +88,9 @@ contract TransferERC20HookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), token);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), to);
     }
 
     function _encodeData(bool usePrev) internal view returns (bytes memory) {

--- a/test/unit/hooks/vaults/5115/ApproveAndDeposit5115VaultHook.t.sol
+++ b/test/unit/hooks/vaults/5115/ApproveAndDeposit5115VaultHook.t.sol
@@ -15,10 +15,12 @@ import { ISuperExecutor } from "../../../../../src/interfaces/ISuperExecutor.sol
 import { IStandardizedYield } from "../../../../../src/vendor/pendle/IStandardizedYield.sol";
 import { MockLedger, MockLedgerConfiguration } from "../../../../mocks/MockLedger.sol";
 import { RhinestoneModuleKit, AccountInstance, UserOpData, ModuleKitHelpers } from "modulekit/ModuleKit.sol";
-
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/kernel/types/Constants.sol";
 
 contract ApproveAndDeposit5115VaultHookTest is Helpers, RhinestoneModuleKit, InternalHelpers {
+    using BytesLib for bytes;
+
     ApproveAndDeposit5115VaultHook public hook;
 
     using ModuleKitHelpers for *;
@@ -200,6 +202,9 @@ contract ApproveAndDeposit5115VaultHookTest is Helpers, RhinestoneModuleKit, Int
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), token);
     }
 
     function _encodeData(bool usePrevHook) internal view returns (bytes memory) {

--- a/test/unit/hooks/vaults/5115/Deposit5115VaultHook.t.sol
+++ b/test/unit/hooks/vaults/5115/Deposit5115VaultHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract Deposit5115VaultHookTest is Helpers {
+    using BytesLib for bytes;
+
     Deposit5115VaultHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -120,6 +123,9 @@ contract Deposit5115VaultHookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), token);
     }
 
     function _encodeData(bool usePrevHook) internal view returns (bytes memory) {

--- a/test/unit/hooks/vaults/5115/Redeem5115VaultHook.t.sol
+++ b/test/unit/hooks/vaults/5115/Redeem5115VaultHook.t.sol
@@ -8,8 +8,11 @@ import { MockERC20 } from "../../../../mocks/MockERC20.sol";
 import { MockHook } from "../../../../mocks/MockHook.sol";
 import { BaseHook } from "../../../../../src/hooks/BaseHook.sol";
 import { Helpers } from "../../../../utils/Helpers.sol";
+import { BytesLib } from "../../../../../src/vendor/BytesLib.sol";
 
 contract Redeem5115VaultHookTest is Helpers {
+    using BytesLib for bytes;
+
     Redeem5115VaultHook public hook;
 
     bytes32 yieldSourceOracleId;
@@ -119,6 +122,9 @@ contract Redeem5115VaultHookTest is Helpers {
         bytes memory data = _encodeData(false);
         bytes memory argsEncoded = hook.inspect(data);
         assertGt(argsEncoded.length, 0);
+
+        assertEq(BytesLib.toAddress(argsEncoded, 0), yieldSource);
+        assertEq(BytesLib.toAddress(argsEncoded, 20), token);
     }
 
     function _encodeData(bool usePrevHook) internal view returns (bytes memory) {


### PR DESCRIPTION
This PR adds the `token` address to the `inspect()` function of `ApproveAndGearboxStakeHook` for validation.

It also adds decoded address validation to `inspect()` function tests for all hooks. 