### PR TITLE
feat: sup 13091 composite hook flow tests

### DIFF
--- a/test/integration/CompositeHookFlowTests.t.sol
+++ b/test/integration/CompositeHookFlowTests.t.sol
@@ -214,7 +214,7 @@ contract CompositeHookFlowTests is BaseTest {
         // Redeem from 4626 vault
         _execute4626RedeemFlow(userShares);
 
-        // Verify fee amounts from redeeming are co rrect
+        // Verify fee amounts from redeeming are correct
         uint256 userBalanceAfterRedeem = IERC20(underlyingETH_USDC).balanceOf(accountEth);
 
         assertEq(userBalanceAfterRedeem, expectedUserAssets);

--- a/test/integration/CompositeHookFlowTests.t.sol
+++ b/test/integration/CompositeHookFlowTests.t.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+// external
+import { console2 } from "forge-std/console2.sol";
+import { UserOpData } from "modulekit/ModuleKit.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { ExecutionLib } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
+import { MODULE_TYPE_EXECUTOR } from "modulekit/accounts/kernel/types/Constants.sol";
+import { UserOpData, AccountInstance, ModuleKitHelpers } from "modulekit/ModuleKit.sol";
+import { IGearboxFarmingPool } from "../../src/vendor/gearbox/IGearboxFarmingPool.sol";
+
+// Superform
+import { BaseTest } from "../BaseTest.t.sol";
+import { SuperLedger } from "../../src/accounting/SuperLedger.sol";
+import { SuperExecutor } from "../../src/executors/SuperExecutor.sol";
+import { ISuperExecutor } from "../../src/interfaces/ISuperExecutor.sol";
+import { ISuperLedgerConfiguration } from "../../src/interfaces/accounting/ISuperLedgerConfiguration.sol";
+import { ERC4626YieldSourceOracle } from "../../src/accounting/oracles/ERC4626YieldSourceOracle.sol";
+import { StakingYieldSourceOracle } from "../../src/accounting/oracles/StakingYieldSourceOracle.sol";
+// import { ERC5115YieldSourceOracle } from "../../src/accounting/oracles/ERC5115YieldSourceOracle.sol";
+import { SuperLedgerConfiguration } from "../../src/accounting/SuperLedgerConfiguration.sol";
+
+contract CompositeHookFlowTests is BaseTest {
+    using ModuleKitHelpers for *;
+    using ExecutionLib for *;
+
+    uint256 depositAmount = 1e18;
+
+    // IStandardizedYield public vaultInstance5115ETH;
+    IERC4626 public vaultInstance4626;
+    IGearboxFarmingPool public gearboxStaking;
+
+    address public underlyingETH_USDC;
+    // address public underlyingETH_sUSDe;
+
+    address public yieldSource4626AddressUSDC;
+    address public yieldSourceStakingAddress;
+
+    address public accountEth;
+    AccountInstance public instanceOnEth;
+
+    SuperLedger public superLedger;
+    SuperLedgerConfiguration public config;
+
+    SuperExecutor public superExecutor;
+    ISuperExecutor public superExecutorInterface;
+
+    ERC4626YieldSourceOracle public oracle4626;
+    StakingYieldSourceOracle public oracleStaking;
+    // ERC5115YieldSourceOracle public oracle5115;
+
+    address public manager;
+    address public feeRecipient;
+
+    bytes32 public yieldSourceOracleId4626;
+    bytes32 public yieldSourceOracleIdStaking;
+    // bytes32 public yieldSourceOracleId5115;
+
+    function setUp() public override {
+        super.setUp();
+        vm.selectFork(FORKS[ETH]);
+
+        instanceOnEth = accountInstances[ETH];
+        accountEth = instanceOnEth.account;
+
+        underlyingETH_USDC = CHAIN_1_USDC;
+
+        _getTokens(underlyingETH_USDC, accountEth, 1e18);
+
+        yieldSource4626AddressUSDC = CHAIN_1_GearboxVault;
+        vaultInstance4626 = IERC4626(yieldSource4626AddressUSDC);
+
+        yieldSourceStakingAddress = CHAIN_1_GearboxStaking;
+        gearboxStaking = IGearboxFarmingPool(yieldSourceStakingAddress);
+
+        config = new SuperLedgerConfiguration();
+        superExecutor = new SuperExecutor(address(config));
+        superExecutorInterface = ISuperExecutor(address(superExecutor));
+
+        address[] memory executors = new address[](1);
+        executors[0] = address(superExecutor);
+
+        superLedger = new SuperLedger(address(config), executors);
+
+        instanceOnEth.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: address(superExecutor), data: "" });
+
+        oracle4626 = new ERC4626YieldSourceOracle(address(superLedger));
+        oracleStaking = new StakingYieldSourceOracle(address(superLedger));
+
+        feeRecipient = makeAddr("feeRecipient");
+        manager = makeAddr("manager");
+
+        bytes32[] memory yieldSourceOracleSalts = new bytes32[](2);
+        yieldSourceOracleSalts[0] = bytes32(keccak256("4626_ORACLE_ID"));
+        yieldSourceOracleSalts[1] = bytes32(keccak256("STAKING_ORACLE_ID"));
+
+        yieldSourceOracleId4626 = keccak256(abi.encodePacked(yieldSourceOracleSalts[0], manager));
+        yieldSourceOracleIdStaking = keccak256(abi.encodePacked(yieldSourceOracleSalts[1], manager));
+
+        ISuperLedgerConfiguration.YieldSourceOracleConfigArgs[] memory configs =
+            new ISuperLedgerConfiguration.YieldSourceOracleConfigArgs[](2);
+        configs[0] = ISuperLedgerConfiguration.YieldSourceOracleConfigArgs({
+            yieldSourceOracle: address(oracle4626),
+            feePercent: 2000, // 20%
+            feeRecipient: feeRecipient,
+            ledger: address(superLedger)
+        });
+        configs[1] = ISuperLedgerConfiguration.YieldSourceOracleConfigArgs({
+            yieldSourceOracle: address(oracleStaking),
+            feePercent: 1000, // 10%
+            feeRecipient: feeRecipient,
+            ledger: address(superLedger)
+        });
+
+        // Set the oracle configs
+        vm.prank(manager);
+        config.setYieldSourceOracles(yieldSourceOracleSalts, configs);
+    }
+
+    function test_CompositeHookFlow() public {
+        // Execute 4626 vault deposit
+        address[] memory hooksAddresses = new address[](2);
+        hooksAddresses[0] = _getHookAddress(ETH, APPROVE_ERC20_HOOK_KEY);
+        hooksAddresses[1] = _getHookAddress(ETH, DEPOSIT_4626_VAULT_HOOK_KEY);
+
+        bytes[] memory hooksData = new bytes[](2);
+        hooksData[0] = _createApproveHookData(underlyingETH_USDC, yieldSource4626AddressUSDC, depositAmount, false);
+        hooksData[1] = _createDeposit4626HookData(
+            yieldSourceOracleId4626, yieldSource4626AddressUSDC, depositAmount, false, address(0), 0
+        );
+
+        ISuperExecutor.ExecutorEntry memory entry =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddresses, hooksData: hooksData });
+        UserOpData memory userOpData = _getExecOps(instanceOnEth, superExecutor, abi.encode(entry));
+        executeOp(userOpData);
+
+        uint256 userShares = vaultInstance4626.balanceOf(accountEth);
+        uint256 sharesAsAssets = vaultInstance4626.convertToAssets(userShares);
+
+        (uint256 expectedFee, uint256 expectedUserAssets) = _calculateExpectedFee4626Vault(sharesAsAssets, userShares);
+
+        // Stake vault shares
+        address[] memory hooksAddressesStake = new address[](1);
+        hooksAddressesStake[0] = _getHookAddress(ETH, GEARBOX_APPROVE_AND_STAKE_HOOK_KEY);
+
+        bytes[] memory hooksDataStake = new bytes[](1);
+        hooksDataStake[0] = _createApproveAndGearboxStakeHookData(
+            yieldSourceOracleIdStaking, yieldSourceStakingAddress, yieldSource4626AddressUSDC, userShares, false
+        );
+
+        ISuperExecutor.ExecutorEntry memory entryStake =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddressesStake, hooksData: hooksDataStake });
+        UserOpData memory userOpDataStake = _getExecOps(instanceOnEth, superExecutor, abi.encode(entryStake));
+        executeOp(userOpDataStake);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+    function _calculateExpectedFee4626Vault(
+        uint256 sharesAsAssets,
+        uint256 userShares
+    )
+        internal
+        view
+        returns (uint256 expectedFee, uint256 expectedUserAssets)
+    {
+        expectedFee = superLedger.previewFees(accountEth, yieldSource4626AddressUSDC, sharesAsAssets, userShares, 2000);
+        expectedUserAssets = sharesAsAssets - expectedFee;
+    }
+
+    function _calculateExpectedFeeStaking(
+        uint256 sharesAsAssets,
+        uint256 userShares
+    )
+        internal
+        view
+        returns (uint256 expectedFee, uint256 expectedUserAssets)
+    {
+        expectedFee = superLedger.previewFees(accountEth, yieldSource4626AddressUSDC, sharesAsAssets, userShares, 1000);
+        expectedUserAssets = sharesAsAssets - expectedFee;
+    }
+}

--- a/test/integration/CompositeHookFlowTests.t.sol
+++ b/test/integration/CompositeHookFlowTests.t.sol
@@ -259,6 +259,7 @@ contract CompositeHookFlowTests is BaseTest {
         executeOp(userOpData);
     }
 
+    /// @notice Executes the Gearbox stake flow via hook executions
     function _executeGearboxStakeFlow(uint256 userShares) internal {
         address[] memory hooksAddressesStake = new address[](1);
         hooksAddressesStake[0] = _getHookAddress(ETH, GEARBOX_APPROVE_AND_STAKE_HOOK_KEY);
@@ -274,6 +275,7 @@ contract CompositeHookFlowTests is BaseTest {
         executeOp(userOpDataStake);
     }
 
+    /// @notice Executes the VaultBank lock flow via user calling the lockAsset function
     function _executeVaultBankLockFlow_UserLocksAssets(uint256 amount) internal {
         vm.startPrank(accountEth);
         IERC20(yieldSourceStakingAddress).approve(vaultBankAddressETH, amount);
@@ -285,6 +287,7 @@ contract CompositeHookFlowTests is BaseTest {
         vm.stopPrank();
     }
 
+    /// @notice Executes the VaultBank lock flow via the MintSuperPositionsHook
     function _executeVaultBankLockFlow_ViaHook(uint256 amount) internal {
         address[] memory hooksAddresses = new address[](1);
         hooksAddresses[0] = _getHookAddress(ETH, MINT_SUPERPOSITIONS_HOOK_KEY);
@@ -301,6 +304,7 @@ contract CompositeHookFlowTests is BaseTest {
         executeOp(userOpData);
     }
 
+    /// @notice Executes the VaultBank redeem flow via user calling the burnSuperPosition function
     function _executeVaultBankRedeemFlow_UserUnlocksAssets(uint256 amount) internal {
         vm.selectFork(FORKS[BASE]);
 
@@ -317,6 +321,7 @@ contract CompositeHookFlowTests is BaseTest {
         IVaultBank(vaultBankAddressETH).unlockAsset(accountEth, yieldSourceStakingAddress, amount, 84_532, yieldSourceOracleIdStaking, bytes(""));
     }
 
+    /// @notice Executes the Gearbox unstake flow via hook executions
     function _executeGearboxUnstakeFlow() internal {
         uint256 userStakingBalance = gearboxStaking.balanceOf(accountEth);
 
@@ -334,6 +339,7 @@ contract CompositeHookFlowTests is BaseTest {
         executeOp(userOpDataUnstake);
     }
 
+    /// @notice Executes the 4626 vault redeem flow via hook executions
     function _execute4626RedeemFlow(uint256 userShares) internal {
         address[] memory hooksAddressesRedeem = new address[](1);
         hooksAddressesRedeem[0] = _getHookAddress(ETH, REDEEM_4626_VAULT_HOOK_KEY);

--- a/test/integration/CompositeHookFlowTests.t.sol
+++ b/test/integration/CompositeHookFlowTests.t.sol
@@ -228,6 +228,7 @@ contract CompositeHookFlowTests is BaseTest {
     /*//////////////////////////////////////////////////////////////
                             HELPER FUNCTIONS
     //////////////////////////////////////////////////////////////*/
+    /// @notice Calculates the expected fee and user assets for the 4626 vault
     function _calculateExpectedFee4626Vault(
         uint256 sharesAsAssets,
         uint256 userShares
@@ -240,6 +241,7 @@ contract CompositeHookFlowTests is BaseTest {
         expectedUserAssets = sharesAsAssets - expectedFee;
     }
 
+    /// @notice Executes the 4626 vault deposit flow via hook executions
     function _execute4626DepositFlow() internal {
         address[] memory hooksAddresses = new address[](2);
         hooksAddresses[0] = _getHookAddress(ETH, APPROVE_ERC20_HOOK_KEY);
@@ -293,6 +295,9 @@ contract CompositeHookFlowTests is BaseTest {
         ISuperExecutor.ExecutorEntry memory entry =
             ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddresses, hooksData: hooksData });
         UserOpData memory userOpData = _getExecOps(instanceOnEth, superExecutorETH, abi.encode(entry));
+
+        vm.expectEmit(false, false, false, true);
+        emit IVaultBankSource.SharesLocked(yieldSourceOracleIdStaking, accountEth, yieldSourceStakingAddress, amount, uint64(block.chainid), 84_532, 0);
         executeOp(userOpData);
     }
 

--- a/test/integration/CompositeHookFlowTests.t.sol
+++ b/test/integration/CompositeHookFlowTests.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.30;
 // external
 import { console2 } from "forge-std/console2.sol";
 import { UserOpData } from "modulekit/ModuleKit.sol";
+import { MockERC20 } from "../mocks/MockERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { ExecutionLib } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
@@ -15,11 +16,12 @@ import { IGearboxFarmingPool } from "../../src/vendor/gearbox/IGearboxFarmingPoo
 import { BaseTest } from "../BaseTest.t.sol";
 import { SuperLedger } from "../../src/accounting/SuperLedger.sol";
 import { SuperExecutor } from "../../src/executors/SuperExecutor.sol";
+import { IVaultBank } from "../../src/vendor/superform/IVaultBank.sol";
 import { ISuperExecutor } from "../../src/interfaces/ISuperExecutor.sol";
 import { ISuperLedgerConfiguration } from "../../src/interfaces/accounting/ISuperLedgerConfiguration.sol";
+import { MintSuperPositionsHook } from "../../src/hooks/vaults/vault-bank/MintSuperPositionsHook.sol";
 import { ERC4626YieldSourceOracle } from "../../src/accounting/oracles/ERC4626YieldSourceOracle.sol";
 import { StakingYieldSourceOracle } from "../../src/accounting/oracles/StakingYieldSourceOracle.sol";
-// import { ERC5115YieldSourceOracle } from "../../src/accounting/oracles/ERC5115YieldSourceOracle.sol";
 import { SuperLedgerConfiguration } from "../../src/accounting/SuperLedgerConfiguration.sol";
 
 contract CompositeHookFlowTests is BaseTest {
@@ -33,13 +35,17 @@ contract CompositeHookFlowTests is BaseTest {
     IGearboxFarmingPool public gearboxStaking;
 
     address public underlyingETH_USDC;
-    // address public underlyingETH_sUSDe;
 
     address public yieldSource4626AddressUSDC;
     address public yieldSourceStakingAddress;
 
     address public accountEth;
+    address public accountBase;
+
     AccountInstance public instanceOnEth;
+    AccountInstance public instanceOnBase;
+
+    address public vaultBank;
 
     SuperLedger public superLedger;
     SuperLedgerConfiguration public config;
@@ -49,14 +55,13 @@ contract CompositeHookFlowTests is BaseTest {
 
     ERC4626YieldSourceOracle public oracle4626;
     StakingYieldSourceOracle public oracleStaking;
-    // ERC5115YieldSourceOracle public oracle5115;
 
     address public manager;
     address public feeRecipient;
 
     bytes32 public yieldSourceOracleId4626;
     bytes32 public yieldSourceOracleIdStaking;
-    // bytes32 public yieldSourceOracleId5115;
+    bytes32 public yieldSourceOracleIdVaultBank;
 
     function setUp() public override {
         super.setUp();
@@ -92,6 +97,8 @@ contract CompositeHookFlowTests is BaseTest {
         feeRecipient = makeAddr("feeRecipient");
         manager = makeAddr("manager");
 
+        yieldSourceOracleIdVaultBank = bytes32(keccak256("VAULT_BANK_ORACLE_ID"));
+
         bytes32[] memory yieldSourceOracleSalts = new bytes32[](2);
         yieldSourceOracleSalts[0] = bytes32(keccak256("4626_ORACLE_ID"));
         yieldSourceOracleSalts[1] = bytes32(keccak256("STAKING_ORACLE_ID"));
@@ -117,24 +124,19 @@ contract CompositeHookFlowTests is BaseTest {
         // Set the oracle configs
         vm.prank(manager);
         config.setYieldSourceOracles(yieldSourceOracleSalts, configs);
+
+        vm.selectFork(FORKS[BASE]);
+        vaultBank = makeAddr("vaultBank");
+
+        instanceOnBase = accountInstances[BASE];
+        accountBase = instanceOnBase.account;
     }
 
-    function test_CompositeHookFlow() public {
+    function test_CompositeHookFlow_UserLocksAssets() public {
+        vm.selectFork(FORKS[ETH]);
+
         // Execute 4626 vault deposit
-        address[] memory hooksAddresses = new address[](2);
-        hooksAddresses[0] = _getHookAddress(ETH, APPROVE_ERC20_HOOK_KEY);
-        hooksAddresses[1] = _getHookAddress(ETH, DEPOSIT_4626_VAULT_HOOK_KEY);
-
-        bytes[] memory hooksData = new bytes[](2);
-        hooksData[0] = _createApproveHookData(underlyingETH_USDC, yieldSource4626AddressUSDC, depositAmount, false);
-        hooksData[1] = _createDeposit4626HookData(
-            yieldSourceOracleId4626, yieldSource4626AddressUSDC, depositAmount, false, address(0), 0
-        );
-
-        ISuperExecutor.ExecutorEntry memory entry =
-            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddresses, hooksData: hooksData });
-        UserOpData memory userOpData = _getExecOps(instanceOnEth, superExecutor, abi.encode(entry));
-        executeOp(userOpData);
+        _execute4626DepositFlow();
 
         uint256 userShares = vaultInstance4626.balanceOf(accountEth);
         uint256 sharesAsAssets = vaultInstance4626.convertToAssets(userShares);
@@ -142,18 +144,48 @@ contract CompositeHookFlowTests is BaseTest {
         (uint256 expectedFee, uint256 expectedUserAssets) = _calculateExpectedFee4626Vault(sharesAsAssets, userShares);
 
         // Stake vault shares
-        address[] memory hooksAddressesStake = new address[](1);
-        hooksAddressesStake[0] = _getHookAddress(ETH, GEARBOX_APPROVE_AND_STAKE_HOOK_KEY);
+        _executeGearboxStakeFlow(userShares);
 
-        bytes[] memory hooksDataStake = new bytes[](1);
-        hooksDataStake[0] = _createApproveAndGearboxStakeHookData(
-            yieldSourceOracleIdStaking, yieldSourceStakingAddress, yieldSource4626AddressUSDC, userShares, false
-        );
+        uint256 userSharesStaking = gearboxStaking.balanceOf(accountEth);
 
-        ISuperExecutor.ExecutorEntry memory entryStake =
-            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddressesStake, hooksData: hooksDataStake });
-        UserOpData memory userOpDataStake = _getExecOps(instanceOnEth, superExecutor, abi.encode(entryStake));
-        executeOp(userOpDataStake);
+        // Lock staking shares in VaultBank & bridge to another chain
+        _executeVaultBankLockFlow_UserLocksAssets(userSharesStaking);
+
+        // Asynchronous redeem back to ETH & unlock assets
+        _executeVaultBankRedeemFlow_UserUnLocksAssets(userSharesStaking, yieldSourceStakingAddress);
+
+        // Withdraw from staking protocol
+        _executeGearboxUnstakeFlow();
+
+        // Redeem from 4626 vault
+        _execute4626RedeemFlow(userShares);
+
+        // Verify fee amounts from redeeming are co rrect
+        uint256 userBalanceAfterRedeem = IERC20(underlyingETH_USDC).balanceOf(accountEth);
+
+        assertEq(userBalanceAfterRedeem, expectedUserAssets);
+        assertEq(IERC20(underlyingETH_USDC).balanceOf(feeRecipient), expectedFee);
+
+        // Verify vault and staking balances are 0
+        assertEq(vaultInstance4626.balanceOf(accountEth), 0);
+        assertEq(gearboxStaking.balanceOf(accountEth), 0);
+    }
+
+    function test_CompositeHookFlow_SharesLocked_ViaPriorHook() public {
+        vm.selectFork(FORKS[ETH]);
+
+        // Execute 4626 vault deposit
+        _execute4626DepositFlow();
+
+        uint256 userShares = vaultInstance4626.balanceOf(accountEth);
+        uint256 sharesAsAssets = vaultInstance4626.convertToAssets(userShares);
+
+        (uint256 expectedFee, uint256 expectedUserAssets) = _calculateExpectedFee4626Vault(sharesAsAssets, userShares);
+
+        // Stake vault shares
+        _executeGearboxStakeFlow(userShares);
+
+        uint256 userSharesStaking = gearboxStaking.balanceOf(accountEth);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -171,15 +203,95 @@ contract CompositeHookFlowTests is BaseTest {
         expectedUserAssets = sharesAsAssets - expectedFee;
     }
 
-    function _calculateExpectedFeeStaking(
-        uint256 sharesAsAssets,
-        uint256 userShares
-    )
-        internal
-        view
-        returns (uint256 expectedFee, uint256 expectedUserAssets)
-    {
-        expectedFee = superLedger.previewFees(accountEth, yieldSource4626AddressUSDC, sharesAsAssets, userShares, 1000);
-        expectedUserAssets = sharesAsAssets - expectedFee;
+    function _execute4626DepositFlow() internal {
+        address[] memory hooksAddresses = new address[](2);
+        hooksAddresses[0] = _getHookAddress(ETH, APPROVE_ERC20_HOOK_KEY);
+        hooksAddresses[1] = _getHookAddress(ETH, DEPOSIT_4626_VAULT_HOOK_KEY);
+
+        bytes[] memory hooksData = new bytes[](2);
+        hooksData[0] = _createApproveHookData(underlyingETH_USDC, yieldSource4626AddressUSDC, depositAmount, false);
+        hooksData[1] = _createDeposit4626HookData(
+            yieldSourceOracleId4626, yieldSource4626AddressUSDC, depositAmount, false, address(0), 0
+        );
+
+        ISuperExecutor.ExecutorEntry memory entry =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddresses, hooksData: hooksData });
+        UserOpData memory userOpData = _getExecOps(instanceOnEth, superExecutor, abi.encode(entry));
+        executeOp(userOpData);
+    }
+
+    function _executeGearboxStakeFlow(uint256 userShares) internal {
+        address[] memory hooksAddressesStake = new address[](1);
+        hooksAddressesStake[0] = _getHookAddress(ETH, GEARBOX_APPROVE_AND_STAKE_HOOK_KEY);
+
+        bytes[] memory hooksDataStake = new bytes[](1);
+        hooksDataStake[0] = _createApproveAndGearboxStakeHookData(
+            yieldSourceOracleIdStaking, yieldSourceStakingAddress, yieldSource4626AddressUSDC, userShares, false
+        );
+
+        ISuperExecutor.ExecutorEntry memory entryStake =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddressesStake, hooksData: hooksDataStake });
+        UserOpData memory userOpDataStake = _getExecOps(instanceOnEth, superExecutor, abi.encode(entryStake));
+        executeOp(userOpDataStake);
+    }
+
+    function _executeVaultBankLockFlow_UserLocksAssets(uint256 amount) internal {
+        address[] memory hooksAddresses = new address[](1);
+        hooksAddresses[0] = address(new MintSuperPositionsHook());
+
+        address spToken = yieldSourceStakingAddress;
+
+        bytes[] memory hooksData = new bytes[](1);
+        hooksData[0] =
+            _createMintSuperPositionsHookData(yieldSourceOracleIdVaultBank, spToken, amount, false, vaultBank, 84_532);
+
+        ISuperExecutor.ExecutorEntry memory entry =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddresses, hooksData: hooksData });
+        UserOpData memory userOpData = _getExecOps(instanceOnEth, superExecutor, abi.encode(entry));
+        executeOp(userOpData);
+    }
+
+    function _executeVaultBankRedeemFlow_UserUnLocksAssets(uint256 amount, address spToken) internal {
+        vm.selectFork(FORKS[BASE]);
+
+        vm.startPrank(accountBase);
+        // IVaultBank(vaultBank).burnSuperPosition(amount, spToken, 1, yieldSourceOracleIdVaultBank);
+        vm.stopPrank();
+
+        vm.selectFork(FORKS[ETH]);
+        //IVaultBank(vaultBank).unlockAsset(accountEth, spToken, amount, 84_532, yieldSourceOracleIdVaultBank, "");
+        vm.stopPrank();
+    }
+
+    function _executeGearboxUnstakeFlow() internal {
+        uint256 userStakingBalance = gearboxStaking.balanceOf(accountEth);
+
+        address[] memory hooksAddressesUnstake = new address[](1);
+        hooksAddressesUnstake[0] = _getHookAddress(ETH, GEARBOX_UNSTAKE_HOOK_KEY);
+
+        bytes[] memory hooksDataUnstake = new bytes[](1);
+        hooksDataUnstake[0] = _createGearboxUnstakeHookData(
+            yieldSourceOracleIdStaking, yieldSourceStakingAddress, userStakingBalance, false
+        );
+
+        ISuperExecutor.ExecutorEntry memory entryUnstake =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddressesUnstake, hooksData: hooksDataUnstake });
+        UserOpData memory userOpDataUnstake = _getExecOps(instanceOnEth, superExecutor, abi.encode(entryUnstake));
+        executeOp(userOpDataUnstake);
+    }
+
+    function _execute4626RedeemFlow(uint256 userShares) internal {
+        address[] memory hooksAddressesRedeem = new address[](1);
+        hooksAddressesRedeem[0] = _getHookAddress(ETH, REDEEM_4626_VAULT_HOOK_KEY);
+
+        bytes[] memory hooksDataRedeem = new bytes[](1);
+        hooksDataRedeem[0] = _createRedeem4626HookData(
+            yieldSourceOracleId4626, yieldSource4626AddressUSDC, accountEth, userShares, false
+        );
+
+        ISuperExecutor.ExecutorEntry memory entryRedeem =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddressesRedeem, hooksData: hooksDataRedeem });
+        UserOpData memory userOpDataRedeem = _getExecOps(instanceOnEth, superExecutor, abi.encode(entryRedeem));
+        executeOp(userOpDataRedeem);
     }
 }

--- a/test/integration/CompositeHookFlowTests.t.sol
+++ b/test/integration/CompositeHookFlowTests.t.sol
@@ -173,7 +173,7 @@ contract CompositeHookFlowTests is BaseTest {
         // Redeem from 4626 vault
         _execute4626RedeemFlow(userShares);
 
-        // Verify fee amounts from redeeming are co rrect
+        // Verify fee amounts from redeeming are correct
         uint256 userBalanceAfterRedeem = IERC20(underlyingETH_USDC).balanceOf(accountEth);
 
         assertEq(userBalanceAfterRedeem, expectedUserAssets);

--- a/test/mocks/MockVaultBank.sol
+++ b/test/mocks/MockVaultBank.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.30;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IVaultBank, IVaultBankSource, IVaultBankDestination } from "../../src/vendor/superform/IVaultBank.sol";
+
+contract MockVaultBank {
+    function lockAsset(
+        bytes32 yieldSourceOracleId,
+        address account,
+        address token,
+        address,
+        uint256 amount,
+        uint64 toChainId
+    )
+        external
+    {
+        IERC20(token).transferFrom(account, address(this), amount);
+
+        emit IVaultBankSource.SharesLocked(yieldSourceOracleId, account, token, amount, uint64(block.chainid), toChainId, 0);
+    }
+
+    function burnSuperPosition(
+        uint256 amount_,
+        address,
+        uint64,
+        bytes32
+    )
+        external
+    {   
+        emit IVaultBank.SuperpositionsBurned(address(0), address(this), address(0), amount_, uint64(block.chainid), 0);
+    }
+
+    function unlockAsset(
+        address account,
+        address token,
+        uint256 amount,
+        uint64 fromChainId,
+        bytes32 yieldSourceOracleId,
+        bytes calldata
+    )
+        external
+    {
+        IERC20(token).transfer(account, amount);
+
+        emit IVaultBankSource.SharesUnlocked( yieldSourceOracleId, account, token, amount, uint64(block.chainid), fromChainId, 0);
+    }
+}

--- a/test/utils/InternalHelpers.sol
+++ b/test/utils/InternalHelpers.sol
@@ -865,4 +865,15 @@ abstract contract InternalHelpers is Test {
     {
         return abi.encodePacked(part1, part2);
     }
+
+    function _createMintSuperPositionsHookData(
+        bytes32 yieldSourceOracleId,
+        address spToken,
+        uint256 amount,
+        bool usePrevHookAmount,
+        address vaultBank,
+        uint256 dstChainId
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(yieldSourceOracleId, spToken, amount, usePrevHookAmount, vaultBank, dstChainId);
+    }
 }


### PR DESCRIPTION
This PR adds two tests for composite hook flows where a user deposits to the forked Gearbox 4626 vault on ETH, stakes the vault shares, uses VaultBank to bridge stakes to Base, then asynchronously redeems back and finally withdraws from the vault. State and  and fee checks are taken at each step.

The first test locks the staked shares into VaultBank by having the user call `lockAssets()` directly and the second test locks the staked shares into VaultBank by executing the `MintSuperPositions` hook.