### PR TITLE
feat: add test for calldata bundler handling

### DIFF
--- a/test/integration/CrosschainTests.sol
+++ b/test/integration/CrosschainTests.sol
@@ -2077,7 +2077,8 @@ contract CrosschainTests is BaseTest {
                 tokenSent: underlyingBase_USDC
             });
 
-            (params.targetExecutorMessage, params.accountToUse) = _createTargetExecutorMessage(params.messageData, false);
+            (params.targetExecutorMessage, params.accountToUse) =
+                _createTargetExecutorMessage(params.messageData, false);
         }
 
         _getTokens(underlyingBase_USDC, params.accountToUse, params.previewRedeemAmount);
@@ -2411,6 +2412,121 @@ contract CrosschainTests is BaseTest {
         //_processDebridgeDlnMessage(BASE, ETH, returnData);
     }
 
+    function test_FAILS_ETH_Bridge_And_Deposit_Calldata_Tamper() public {
+        uint256 amountPerVault = 1e8;
+
+        // ETH IS DST
+        SELECT_FORK_AND_WARP(ETH, WARP_START_TIME);
+
+        // PREPARE ETH DATA (This becomes the *payload* for the Debridge external call)
+        bytes memory innerExecutorPayload;
+        TargetExecutorMessage memory messageData;
+        address accountToUse;
+        {
+            address[] memory eth7540HooksAddresses = new address[](2);
+            eth7540HooksAddresses[0] = _getHookAddress(ETH, APPROVE_ERC20_HOOK_KEY);
+            eth7540HooksAddresses[1] = _getHookAddress(ETH, REQUEST_DEPOSIT_7540_VAULT_HOOK_KEY);
+
+            bytes[] memory eth7540HooksData = new bytes[](2);
+            eth7540HooksData[0] =
+                _createApproveHookData(underlyingETH_USDC, yieldSource7540AddressETH_USDC, amountPerVault, false);
+            eth7540HooksData[1] = _createRequestDeposit7540VaultHookData(
+                _getYieldSourceOracleId(bytes32(bytes(ERC7540_YIELD_SOURCE_ORACLE_KEY)), MANAGER),
+                yieldSource7540AddressETH_USDC,
+                amountPerVault,
+                true
+            );
+
+            messageData = TargetExecutorMessage({
+                hooksAddresses: eth7540HooksAddresses,
+                hooksData: eth7540HooksData,
+                validator: address(destinationValidatorOnETH),
+                signer: validatorSigners[ETH],
+                signerPrivateKey: validatorSignerPrivateKeys[ETH],
+                targetAdapter: address(debridgeAdapterOnETH),
+                targetExecutor: address(superTargetExecutorOnETH),
+                nexusFactory: CHAIN_1_NEXUS_FACTORY,
+                nexusBootstrap: CHAIN_1_NEXUS_BOOTSTRAP,
+                chainId: uint64(ETH),
+                amount: amountPerVault,
+                account: accountETH,
+                tokenSent: underlyingETH_USDC
+            });
+
+            (innerExecutorPayload, accountToUse) = _createTargetExecutorMessage(messageData, false);
+        }
+
+        // BASE IS SRC
+        SELECT_FORK_AND_WARP(BASE, WARP_START_TIME + 30 days);
+
+        uint256 user_Base_USDC_Balance_Before = IERC20(underlyingBase_USDC).balanceOf(accountBase);
+
+        // PREPARE BASE DATA
+        address[] memory srcHooksAddresses = new address[](2);
+        srcHooksAddresses[0] = _getHookAddress(BASE, APPROVE_ERC20_HOOK_KEY);
+        srcHooksAddresses[1] = _getHookAddress(BASE, DEBRIDGE_SEND_ORDER_AND_EXECUTE_ON_DST_HOOK_KEY);
+
+        uint256 msgValue = IDlnSource(DEBRIDGE_DLN_ADDRESSES[BASE]).globalFixedNativeFee();
+
+        bytes[] memory srcHooksData = new bytes[](2);
+        srcHooksData[0] =
+            _createApproveHookData(underlyingBase_USDC, DEBRIDGE_DLN_ADDRESSES[BASE], amountPerVault, false);
+
+        bytes memory debridgeData = _createDebridgeSendFundsAndExecuteHookData(
+            DebridgeOrderData({
+                usePrevHookAmount: false, //usePrevHookAmount
+                value: msgValue, //value
+                giveTokenAddress: underlyingBase_USDC, //giveTokenAddress
+                giveAmount: amountPerVault, //giveAmount
+                version: 1, //envelope.version
+                fallbackAddress: accountETH, //envelope.fallbackAddress
+                executorAddress: address(debridgeAdapterOnETH), //envelope.executorAddress
+                executionFee: uint160(0), //envelope.executionFee
+                allowDelayedExecution: false, //envelope.allowDelayedExecution
+                requireSuccessfulExecution: true, //envelope.requireSuccessfulExecution
+                payload: innerExecutorPayload, //envelope.payload
+                takeTokenAddress: underlyingETH_USDC, //takeTokenAddress
+                takeAmount: amountPerVault - amountPerVault * 1e4 / 1e5, //takeAmount
+                takeChainId: ETH, //takeChainId
+                // receiverDst must be the Debridge Adapter on the destination chain
+                receiverDst: address(debridgeAdapterOnETH),
+                givePatchAuthoritySrc: address(0), //givePatchAuthoritySrc
+                orderAuthorityAddressDst: abi.encodePacked(accountETH), //orderAuthorityAddressDst
+                allowedTakerDst: "", //allowedTakerDst
+                allowedCancelBeneficiarySrc: "", //allowedCancelBeneficiarySrc
+                affiliateFee: "", //affiliateFee
+                referralCode: 0 //referralCode
+             })
+        );
+        srcHooksData[1] = debridgeData;
+
+        UserOpData memory srcUserOpData = _createUserOpData(srcHooksAddresses, srcHooksData, BASE, true);
+
+        // MALICIOUS BUNDLER TAMPERS WITH CALLDATA
+        // Tamper with the calldata in the debridge hook
+        // This simulates a malicious bundler modifying the execution payload to redirect funds
+        // Create a malicious payload that changes the destination account
+
+        // Extract the original payload from the debridge data
+        // The payload is located after the fixed fields in the debridge data
+        bytes memory originalPayload = innerExecutorPayload;
+
+        // Recreate user operation with tampered calldata
+        srcUserOpData = _createUserOpDataWithCalldataTamper(
+            amountPerVault, msgValue, srcHooksAddresses, srcHooksData, originalPayload
+        );
+
+        // Execute op on src chain - this should fail due to calldata tampering
+        // The validation should detect that the calldata doesn't match the signed data
+        vm.expectRevert(SuperValidatorBase.INVALID_PROOF.selector);
+        instanceOnBase.expect4337Revert();
+        executeOp(srcUserOpData);
+        // ^ This should fail because the calldata has been tampered with
+
+        // Verify that user funds remain intact - no actual execution should occur
+        assertEq(IERC20(underlyingBase_USDC).balanceOf(accountBase), user_Base_USDC_Balance_Before);
+    }
+
     function testOrion_maliciousRelayersDoSCrosschainExecution() public {
         uint256 amountPerVault = 1e8 / 2;
 
@@ -2566,8 +2682,9 @@ contract CrosschainTests is BaseTest {
                 account: address(0),
                 tokenSent: underlyingETH_USDC
             });
-            
-            (testData.targetExecutorMessage, testData.accountToUse) = _createTargetExecutorMessage(testData.messageData, false);
+
+            (testData.targetExecutorMessage, testData.accountToUse) =
+                _createTargetExecutorMessage(testData.messageData, false);
         }
 
         // BASE IS SRC
@@ -3561,7 +3678,7 @@ contract CrosschainTests is BaseTest {
         bytes memory targetExecutorMessage;
         address accountToUse;
         (targetExecutorMessage, accountToUse) = _createTargetExecutorMessage(messageData, false);
-        
+
         SELECT_FORK_AND_WARP(BASE, WARP_START_TIME + 30 days);
 
         address[] memory srcHooksAddresses = new address[](2);
@@ -4438,5 +4555,76 @@ contract CrosschainTests is BaseTest {
             }
             return _getExecOps(instanceOnBase, superExecutorOnBase, abi.encode(entryToExecute));
         }
+    }
+
+    function _createUserOpDataWithCalldataTamper(
+        uint256 amountPerVault,
+        uint256 msgValue,
+        address[] memory srcHooksAddresses,
+        bytes[] memory srcHooksData,
+        bytes memory originalPayload
+    )
+        internal
+        returns (UserOpData memory)
+    {
+        bytes memory maliciousPayload = _createMaliciousPayload(originalPayload);
+
+        // Create new debridge data with malicious payload
+        bytes memory maliciousDebridgeData = _createDebridgeSendFundsAndExecuteHookData(
+            DebridgeOrderData({
+                usePrevHookAmount: false, //usePrevHookAmount
+                value: msgValue, //value
+                giveTokenAddress: underlyingBase_USDC, //giveTokenAddress
+                giveAmount: amountPerVault, //giveAmount
+                version: 1, //envelope.version
+                fallbackAddress: accountETH, //envelope.fallbackAddress
+                executorAddress: address(debridgeAdapterOnETH), //envelope.executorAddress
+                executionFee: uint160(0), //envelope.executionFee
+                allowDelayedExecution: false, //envelope.allowDelayedExecution
+                requireSuccessfulExecution: true, //envelope.requireSuccessfulExecution
+                payload: maliciousPayload, // Use malicious payload instead of original
+                takeTokenAddress: underlyingETH_USDC, //takeTokenAddress
+                takeAmount: amountPerVault - amountPerVault * 1e4 / 1e5, //takeAmount
+                takeChainId: ETH, //takeChainId
+                // receiverDst must be the Debridge Adapter on the destination chain
+                receiverDst: address(debridgeAdapterOnETH),
+                givePatchAuthoritySrc: address(0), //givePatchAuthoritySrc
+                orderAuthorityAddressDst: abi.encodePacked(accountETH), //orderAuthorityAddressDst
+                allowedTakerDst: "", //allowedTakerDst
+                allowedCancelBeneficiarySrc: "", //allowedCancelBeneficiarySrc
+                affiliateFee: "", //affiliateFee
+                referralCode: 0 //referralCode
+             })
+        );
+
+        // Update the hooks data with malicious calldata
+        srcHooksData[1] = maliciousDebridgeData;
+
+        // Recreate user operation with tampered calldata
+        return _createUserOpData(srcHooksAddresses, srcHooksData, BASE, true);
+    }
+
+    function _createMaliciousPayload(bytes memory originalPayload)
+        internal
+        pure
+        returns (bytes memory maliciousPayload)
+    {
+        (
+            bytes memory accountCreationData,
+            bytes memory executionData,
+            , // originalAccount
+            address[] memory dstTokens,
+            uint256[] memory intentAmounts
+        ) = abi.decode(originalPayload, (bytes, bytes, address, address[], uint256[]));
+
+        // Change the account to a malicious address (attacker's address)
+        address maliciousAccount = address(0xDEADBEEF);
+        maliciousPayload = abi.encode(
+            accountCreationData,
+            executionData,
+            maliciousAccount, // Changed from originalAccount
+            dstTokens,
+            intentAmounts
+        );
     }
 }


### PR DESCRIPTION
Adds a test where a malicious bundler alters the calldata of a deposit operation (redirecting funds). Ensures any such modification causes the transaction to revert and that user funds remain intact.