### PR TITLE
fix: withHook bypass scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ coverage-genhtml :; FOUNDRY_PROFILE=coverage forge coverage --jobs 10 --ir-minim
 
 coverage-genhtml-fullsrc :; FOUNDRY_PROFILE=coverage forge coverage --jobs 10 --ir-minimum --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage --ignore-errors inconsistent,corrupt --exclude 'src/vendor/*' --exclude 'test/*'
 
-test-vvv :; forge test --match-test test_BridgeThroughDifferentAdapters -vvvv --jobs 10
+test-vvv :; forge test --match-test test_feeBypassByResettingExecution -vvvv --jobs 10
 
 test-integration :; forge test --match-test test_CrossChain_execution -vvvv --jobs 10
 

--- a/src/hooks/BaseHook.sol
+++ b/src/hooks/BaseHook.sol
@@ -103,6 +103,11 @@ abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult, IS
         subType = subType_;
     }
 
+    modifier onlyLastCaller() {
+        if (msg.sender != lastCaller) revert UNAUTHORIZED_CALLER();
+        _;
+    }
+
     /*//////////////////////////////////////////////////////////////
                           EXECUTION SECURITY
     //////////////////////////////////////////////////////////////*/
@@ -186,7 +191,7 @@ abstract contract BaseHook is ISuperHook, ISuperHookSetter, ISuperHookResult, IS
     }
 
     /// @inheritdoc ISuperHook
-    function resetExecutionState(address caller) external {
+    function resetExecutionState(address caller) external onlyLastCaller {
         uint256 context = _getCurrentExecutionContext(caller);
         if (!_getPreExecuteMutex(context) || !_getPostExecuteMutex(context)) {
             revert INCOMPLETE_HOOK_EXECUTION();

--- a/src/vendor/nexus/INexus.sol
+++ b/src/vendor/nexus/INexus.sol
@@ -13,7 +13,8 @@ interface INexus {
     /// appropriately.
     function execute(ModeCode mode, bytes calldata executionCalldata) external payable;
     /// @notice Initializes the smart account with a validator and custom data.
-    /// @dev This method sets up the account for operation, linking it with a validator and initializing it with specific data.
+    /// @dev This method sets up the account for operation, linking it with a validator and initializing it with
+    /// specific data.
     /// Can be called directly or via a factory.
     /// @param initData Encoded data used for the account's configuration during initialization.
     function initializeAccount(bytes calldata initData) external payable;
@@ -24,5 +25,12 @@ interface INexus {
     /// @param size The number of validator addresses to return.
     /// @return array An array of validator addresses.
     /// @return next The address to use as a cursor for the next page of results.
-    function getValidatorsPaginated(address cursor, uint256 size) external view returns (address[] memory array, address next);
+    function getValidatorsPaginated(
+        address cursor,
+        uint256 size
+    )
+        external
+        view
+        returns (address[] memory array, address next);
+    function installModule(uint256 moduleTypeId, address module, bytes calldata initData) external payable;
 }

--- a/test/integration/E2EExecution.t.sol
+++ b/test/integration/E2EExecution.t.sol
@@ -8,6 +8,8 @@ import { INexus } from "../../src/vendor/nexus/INexus.sol";
 import { IERC7579Account } from "modulekit/accounts/common/interfaces/IERC7579Account.sol";
 import { IMinimalEntryPoint, PackedUserOperation } from "../../src/vendor/account-abstraction/IMinimalEntryPoint.sol";
 import { Execution } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
+import { ModeLib } from "modulekit/accounts/common/lib/ModeLib.sol";
+import { ExecutionLib } from "modulekit/accounts/erc7579/lib/ExecutionLib.sol";
 
 // Superform
 import { ISuperExecutor } from "../../src/interfaces/ISuperExecutor.sol";
@@ -17,7 +19,6 @@ import { ISuperSignatureStorage } from "../../src/interfaces/ISuperSignatureStor
 import { AcrossSendFundsAndExecuteOnDstHook } from
     "../../src/hooks/bridges/across/AcrossSendFundsAndExecuteOnDstHook.sol";
 import { MinimalBaseNexusIntegrationTest } from "./MinimalBaseNexusIntegrationTest.t.sol";
-
 // edge case & poc mocks
 //  -- used on test_HookPoisoning_ tests to bypass validation from a malicious account
 import { MockValidator } from "../../lib/modulekit/src/module-bases/mocks/MockValidator.sol";
@@ -28,6 +29,55 @@ import { MockMaliciousHook } from "../mocks/MockMaliciousHook.sol";
 
 import "forge-std/console2.sol";
 import "forge-std/Test.sol";
+
+contract MaliciousHookResetExecution {
+    address public account;
+    address public targetHook;
+    uint256 public counter;
+
+    uint256 constant EXECUTOR_TYPE_HOOK = 2;
+    uint256 constant MODULE_TYPE_HOOK = 4;
+
+    bytes public data;
+
+    error ATTACK_FAILED();
+
+    function setAccountAndTargetHook(address _account, address _targetHook) external {
+        account = _account;
+        targetHook = _targetHook;
+    }
+
+    function setTargetCalldata(bytes memory _data) external {
+        data = _data;
+    }
+
+    function preCheck(
+        address msgSender,
+        uint256 msgValue,
+        bytes calldata msgData
+    )
+        external
+        returns (bytes memory hookData)
+    {
+        // do nothing in precheck
+    }
+
+    function postCheck(bytes calldata /*hookData*/ ) external {
+        // Call the account
+        ++counter;
+        if (counter == 4) {
+            (bool success,) = account.call(data);
+
+            if (!success) revert ATTACK_FAILED();
+        }
+    }
+
+    function isModuleType(uint256 moduleTypeID) external pure returns (bool) {
+        return moduleTypeID == MODULE_TYPE_HOOK || moduleTypeID == EXECUTOR_TYPE_HOOK;
+    }
+
+    function onInstall(bytes calldata data) external { }
+}
 
 contract E2EExecutionTest is MinimalBaseNexusIntegrationTest {
     address[] public attesters;
@@ -1085,6 +1135,112 @@ contract E2EExecutionTest is MinimalBaseNexusIntegrationTest {
         // Verify the normal execution worked correctly despite poisoning attempt
         uint256 finalShares = IERC4626(morphoVault).balanceOf(nexusAccount);
         assertGt(finalShares, 0, "Normal execution should have succeeded despite poisoning attempt");
+    }
+
+    function test_feeBypassByResettingExecution() public {
+        uint256 amount = 10_000e6;
+        address underlyingToken = CHAIN_1_USDC;
+        address morphoVault = CHAIN_1_MorphoVault;
+
+        MaliciousHookResetExecution maliciousHookResetExecution = new MaliciousHookResetExecution();
+
+        // Step 1: Create account and install custom malicious hook
+        address nexusAccount =
+            _createWithNexusWithMaliciousHook(attesters, threshold, 1e18, address(maliciousHookResetExecution));
+
+        maliciousHookResetExecution.setAccountAndTargetHook(nexusAccount, redeem4626Hook);
+
+        // add tokens to account
+        _getTokens(underlyingToken, nexusAccount, amount);
+
+        // Step 2: Install hook as an account executor of the account
+        vm.prank(nexusAccount);
+        INexus(nexusAccount).installModule(2, address(maliciousHookResetExecution), "");
+
+        // Configure malicious executions in the hook
+        Execution[] memory executions = new Execution[](3);
+
+        executions[0] = Execution({
+            target: address(redeem4626Hook),
+            value: 0,
+            callData: abi.encodeWithSignature(
+                "resetExecutionState(address)",
+                nexusAccount // account
+            )
+        });
+        bytes memory redeemData = _createRedeem4626HookData(
+            _getYieldSourceOracleId(bytes32(bytes(ERC4626_YIELD_SOURCE_ORACLE_KEY)), address(this)),
+            morphoVault,
+            nexusAccount,
+            IERC4626(morphoVault).convertToShares(amount),
+            false
+        );
+        executions[1] = Execution({
+            target: address(redeem4626Hook),
+            value: 0,
+            callData: abi.encodeWithSignature(
+                "preExecute(address,address,bytes)",
+                address(0), // prevHook
+                nexusAccount,
+                redeemData
+            )
+        });
+        executions[2] = Execution({
+            target: address(redeem4626Hook),
+            value: 0,
+            callData: abi.encodeWithSignature(
+                "postExecute(address,address,bytes)",
+                address(0), // prevHook
+                nexusAccount,
+                redeemData
+            )
+        });
+
+        bytes memory data = abi.encodeCall(
+            IERC7579Account.executeFromExecutor, (ModeLib.encodeSimpleBatch(), ExecutionLib.encodeBatch(executions))
+        );
+
+        maliciousHookResetExecution.setTargetCalldata(data);
+
+        // Step 3. Create SuperExecutor data, with:
+        // - approval
+        // - deposit
+        // - redemption, whose amount should be charged
+
+        address[] memory hooksAddresses = new address[](3);
+        hooksAddresses[0] = approveHook;
+        hooksAddresses[1] = deposit4626Hook;
+        hooksAddresses[2] = redeem4626Hook;
+
+        bytes[] memory hooksData = new bytes[](3);
+        hooksData[0] = _createApproveHookData(underlyingToken, morphoVault, amount, false);
+        hooksData[1] = _createDeposit4626HookData(
+            _getYieldSourceOracleId(bytes32(bytes(ERC4626_YIELD_SOURCE_ORACLE_KEY)), address(this)),
+            morphoVault,
+            amount,
+            false,
+            address(0),
+            0
+        );
+        hooksData[2] = _createRedeem4626HookData(
+            _getYieldSourceOracleId(bytes32(bytes(ERC4626_YIELD_SOURCE_ORACLE_KEY)), address(this)),
+            morphoVault,
+            nexusAccount,
+            IERC4626(morphoVault).convertToShares(amount),
+            false
+        );
+
+        // Step 4. Prepare data and execute through entry point
+        ISuperExecutor.ExecutorEntry memory entry =
+            ISuperExecutor.ExecutorEntry({ hooksAddresses: hooksAddresses, hooksData: hooksData });
+
+        address feeRecipient = makeAddr("feeRecipient"); // this is the recipient configured in base tests.
+
+        // Fetch the fee recipient balance before execution
+        uint256 feeReceiverBalanceBefore = IERC4626(CHAIN_1_USDC).balanceOf(feeRecipient);
+
+        _executeThroughEntrypoint(nexusAccount, entry);
+        _checkUserOperationResults(MaliciousHookResetExecution.ATTACK_FAILED.selector);
     }
 
     function _buildPoisoningUserOp(


### PR DESCRIPTION
- Fixes withHook bypass scenario by requiring the callee to resetExecutionState to be lastCaller

Note: any code that uses hooks outside of a SuperExecutor context cannot execute that code within a SuperExecutor context

