### PR TITLE
patch: removed externalCallAdapter cache from debridge adapter

### DIFF
--- a/src/adapters/DebridgeAdapter.sol
+++ b/src/adapters/DebridgeAdapter.sol
@@ -21,7 +21,7 @@ contract DebridgeAdapter is IExternalCallExecutor {
                                  STORAGE
     //////////////////////////////////////////////////////////////*/
     ISuperDestinationExecutor public immutable SUPER_DESTINATION_EXECUTOR;
-    address public immutable EXTERNAL_CALL_ADAPTER;
+    address public immutable DLN_DESTINATION;
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -39,11 +39,11 @@ contract DebridgeAdapter is IExternalCallExecutor {
         if (_externalCallAdapter == address(0)) {
             revert ADDRESS_NOT_VALID();
         }
-        EXTERNAL_CALL_ADAPTER = _externalCallAdapter;
+        DLN_DESTINATION = dlnDestination;
     }
 
     modifier onlyExternalCallAdapter() {
-        if (msg.sender != EXTERNAL_CALL_ADAPTER) revert ONLY_EXTERNAL_CALL_ADAPTER();
+        if (msg.sender != IDlnDestination(DLN_DESTINATION).externalCallAdapter()) revert ONLY_EXTERNAL_CALL_ADAPTER();
         _;
     }
 

--- a/test/unit/adapters/AdaptersUnitTests.sol
+++ b/test/unit/adapters/AdaptersUnitTests.sol
@@ -106,7 +106,7 @@ contract AcrossV3AdapterTest is Helpers {
         new DebridgeAdapter(address(this), address(0));
 
         DebridgeAdapter adp = new DebridgeAdapter(address(mockDlnDestination), address(0x2));
-        assertEq(adp.EXTERNAL_CALL_ADAPTER(), address(this));
+        assertEq(adp.DLN_DESTINATION(), address(mockDlnDestination));
         assertEq(address(adp.SUPER_DESTINATION_EXECUTOR()), address(0x2));
 
         mockDlnDestination = new MockDlnDestination(address(0));


### PR DESCRIPTION
Fixes https://github.com/orionsecxyz/Superform-Core-V2-Audit/issues/49