### PR TITLE
feat: improve error handling in MockEntrypoint with revert

### DIFF
--- a/test/mocks/simulationHelpers/MockEntrypoint.sol
+++ b/test/mocks/simulationHelpers/MockEntrypoint.sol
@@ -35,8 +35,17 @@ contract MockedEntrypoint {
         uint256 gasBefore = gasleft();
 
         // Execute the call on the account
-        (bool callSuccess,) = account.call(accountCallData);
-        require(callSuccess, "Account call failed");
+        (bool callSuccess, bytes memory returnData) = account.call(accountCallData);
+        if (!callSuccess) {
+            // Bubble up the actual revert reason
+            if (returnData.length > 0) {
+                assembly {
+                    revert(add(returnData, 32), mload(returnData))
+                }
+            } else {
+                revert("Account call failed");
+            }
+        }
 
         // Calculate gas consumed
         uint256 gasAfter = gasleft();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves error propagation during mocked account calls for clearer failures during gas estimation.
> 
> - In `MockedEntrypoint.estimateCall`, capture `(success, returnData)` from `account.call` and, on failure, bubble the revert reason via `assembly` when available; otherwise revert with `"Account call failed"`
> - Gas measurement and signature storage logic unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be3f33411ff111f5db73c6bc7e48a090f8fb7f02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->