### PR TITLE
chore: added support for hyperevm

### DIFF
--- a/script/run/networks-production.sh
+++ b/script/run/networks-production.sh
@@ -14,10 +14,11 @@ NETWORKS=(
     "137:Polygon:POLYGON_MAINNET"
     "130:Unichain:UNICHAIN_MAINNET"
     "43114:Avalanche:AVALANCHE_MAINNET"
-    "80094:Berachain:BERACHAIN_MAINNET" 
+    "80094:Berachain:BERACHAIN_MAINNET"
     "146:Sonic:SONIC_MAINNET"
     "100:Gnosis:GNOSIS_MAINNET"
     "480:Worldchain:WORLDCHAIN_MAINNET"
+    "999:HyperEVM:HYPEREVM_MAINNET"
 )
 
 # Network name mapping function
@@ -59,6 +60,9 @@ get_network_name() {
             ;;
         480)
             echo "Worldchain"
+            ;;
+        999)
+            echo "HyperEVM"
             ;;
         *)
             echo "ERROR: Unknown production network ID: $network_id" >&2
@@ -107,6 +111,9 @@ get_rpc_var() {
         480)
             echo "WORLDCHAIN_MAINNET"
             ;;
+        999)
+            echo "HYPEREVM_MAINNET"
+            ;;
         *)
             echo "ERROR: Unknown production network ID for RPC: $network_id" >&2
             return 1
@@ -153,6 +160,9 @@ get_rpc_url() {
             ;;
         480)
             echo "$WORLDCHAIN_MAINNET"
+            ;;
+        999)
+            echo "$HYPEREVM_MAINNET"
             ;;
         *)
             echo "ERROR: Unknown production network ID for RPC: $network_id" >&2
@@ -272,7 +282,14 @@ load_rpc_urls_ci() {
     else
         failed_rpcs+=("WORLDCHAIN_RPC_URL")
     fi
-    
+
+    echo "  • Loading HyperEVM RPC..."
+    if [[ -n "${HYPEREVM_RPC_URL:-}" ]]; then
+        export HYPEREVM_MAINNET="$HYPEREVM_RPC_URL"
+    else
+        failed_rpcs+=("HYPEREVM_RPC_URL")
+    fi
+
     if [[ ${#failed_rpcs[@]} -gt 0 ]]; then
         echo "❌ Failed to load the following RPC URLs from environment:"
         for failed_rpc in "${failed_rpcs[@]}"; do
@@ -352,7 +369,12 @@ load_rpc_urls() {
     if ! export WORLDCHAIN_MAINNET=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/WORLDCHAIN_RPC_URL/credential 2>/dev/null); then
         failed_rpcs+=("WORLDCHAIN_RPC_URL")
     fi
-    
+
+    echo "  • Loading HyperEVM RPC..."
+    if ! export HYPEREVM_MAINNET=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/HYPEREVM_RPC_URL/credential 2>/dev/null); then
+        failed_rpcs+=("HYPEREVM_RPC_URL")
+    fi
+
     if [[ ${#failed_rpcs[@]} -gt 0 ]]; then
         echo "❌ Failed to load the following RPC URLs from 1Password:"
         for failed_rpc in "${failed_rpcs[@]}"; do

--- a/script/run/verify_v2_staging_prod.sh
+++ b/script/run/verify_v2_staging_prod.sh
@@ -131,18 +131,19 @@ load_contract_addresses() {
         "146") network_suffix="Sonic-latest" ;;
         "100") network_suffix="Gnosis-latest" ;;
         "480") network_suffix="Worldchain-latest" ;;
+        "999") network_suffix="HyperEVM-latest" ;;
         *) network_suffix="${network_name}-latest" ;;
     esac
-    
+
     local json_file="script/output/$ENVIRONMENT/$chain_id/$network_suffix.json"
-    
+
     if [ ! -f "$json_file" ]; then
         echo -e "${RED}❌ JSON file not found: $json_file${NC}"
         echo -e "${RED}   Expected path: $json_file${NC}"
         echo -e "${YELLOW}   Make sure contracts have been deployed to this network first${NC}"
         return 1
     fi
-    
+
     echo -e "${CYAN}   • Loading addresses from: $json_file${NC}"
     return 0
 }
@@ -168,14 +169,15 @@ get_contract_address() {
         "146") network_suffix="Sonic-latest" ;;
         "100") network_suffix="Gnosis-latest" ;;
         "480") network_suffix="Worldchain-latest" ;;
-        *) 
+        "999") network_suffix="HyperEVM-latest" ;;
+        *)
             local network_name=$(get_network_name "$chain_id")
             network_suffix="${network_name}-latest"
             ;;
     esac
-    
+
     local json_file="script/output/$ENVIRONMENT/$chain_id/$network_suffix.json"
-    
+
     if [ -f "$json_file" ]; then
         local address=$(jq -r ".$contract_name // empty" "$json_file")
         echo "$address"
@@ -306,6 +308,14 @@ generate_constructor_args() {
             odos_router=""  # Not deployed
             across_spoke_pool_v3="0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64"
             merkl_distributor="0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae"
+            native_token="0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            ;;
+        "999") # HyperEVM (Hyperliquid)
+            permit2=""  # Not deployed
+            aggregation_router=""  # Not deployed
+            odos_router=""  # Not deployed
+            across_spoke_pool_v3=""  # Not deployed
+            merkl_distributor=""  # Not deployed
             native_token="0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
             ;;
     esac
@@ -543,11 +553,12 @@ verify_network() {
         "146") network_suffix="Sonic-latest" ;;
         "100") network_suffix="Gnosis-latest" ;;
         "480") network_suffix="Worldchain-latest" ;;
+        "999") network_suffix="HyperEVM-latest" ;;
         *) network_suffix="${network_name}-latest" ;;
     esac
-    
+
     local json_file="script/output/$ENVIRONMENT/$chain_id/$network_suffix.json"
-    
+
     if [ ! -f "$json_file" ]; then
         echo -e "${RED}   ❌ Contract addresses file not found: $json_file${NC}"
         return 1

--- a/script/utils/ConfigBase.sol
+++ b/script/utils/ConfigBase.sol
@@ -75,6 +75,7 @@ abstract contract ConfigBase is Constants {
         chainNames[SONIC_CHAIN_ID] = SONIC_KEY;
         chainNames[GNOSIS_CHAIN_ID] = GNOSIS_KEY;
         chainNames[WORLDCHAIN_CHAIN_ID] = WORLDCHAIN_KEY;
+        chainNames[HYPEREVM_CHAIN_ID] = HYPEREVM_KEY;
 
         // ===== COMMON CONFIGURATION =====
         if (env_ == 0 || env_ == 2) {

--- a/script/utils/ConfigCore.sol
+++ b/script/utils/ConfigCore.sol
@@ -28,6 +28,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.acrossSpokePoolV3s[SONIC_CHAIN_ID] = address(0); // Not deployed yet
         configuration.acrossSpokePoolV3s[GNOSIS_CHAIN_ID] = address(0); // Not deployed yet
         configuration.acrossSpokePoolV3s[WORLDCHAIN_CHAIN_ID] = ACROSS_SPOKE_POOL_WORLDCHAIN;
+        configuration.acrossSpokePoolV3s[HYPEREVM_CHAIN_ID] = address(0); // Not deployed yet
 
         // ===== DEBRIDGE DLN SOURCE ADDRESSES =====
         configuration.debridgeSrcDln[MAINNET_CHAIN_ID] = DEBRIDGE_DLN_SRC;
@@ -43,6 +44,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.debridgeSrcDln[SONIC_CHAIN_ID] = DEBRIDGE_DLN_SRC;
         configuration.debridgeSrcDln[GNOSIS_CHAIN_ID] = DEBRIDGE_DLN_SRC;
         configuration.debridgeSrcDln[WORLDCHAIN_CHAIN_ID] = address(0); // Not deployed yet
+        configuration.debridgeSrcDln[HYPEREVM_CHAIN_ID] = address(0); // Not deployed yet
 
         // ===== DEBRIDGE DLN DESTINATION ADDRESSES =====
         configuration.debridgeDstDln[MAINNET_CHAIN_ID] = DEBRIDGE_DLN_DST;
@@ -58,6 +60,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.debridgeDstDln[SONIC_CHAIN_ID] = DEBRIDGE_DLN_DST;
         configuration.debridgeDstDln[GNOSIS_CHAIN_ID] = DEBRIDGE_DLN_DST;
         configuration.debridgeDstDln[WORLDCHAIN_CHAIN_ID] = address(0); // Not deployed yet
+        configuration.debridgeDstDln[HYPEREVM_CHAIN_ID] = address(0); // Not deployed yet
 
         // ===== PERMIT2 ADDRESSES =====
         configuration.permit2s[MAINNET_CHAIN_ID] = PERMIT2;
@@ -73,6 +76,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.permit2s[SONIC_CHAIN_ID] = PERMIT2;
         configuration.permit2s[GNOSIS_CHAIN_ID] = PERMIT2;
         configuration.permit2s[WORLDCHAIN_CHAIN_ID] = PERMIT2;
+        configuration.permit2s[HYPEREVM_CHAIN_ID] = address(0); // Not deployed yet
 
         // ===== MERKL DISTRIBUTOR ADDRESSES =====
         configuration.merklDistributors[MAINNET_CHAIN_ID] = MERKL_DISTRIBUTOR;
@@ -88,6 +92,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.merklDistributors[SONIC_CHAIN_ID] = MERKL_DISTRIBUTOR;
         configuration.merklDistributors[GNOSIS_CHAIN_ID] = MERKL_DISTRIBUTOR;
         configuration.merklDistributors[WORLDCHAIN_CHAIN_ID] = MERKL_DISTRIBUTOR;
+        configuration.merklDistributors[HYPEREVM_CHAIN_ID] = address(0); // Not deployed yet
 
         // ===== CRITICAL ROUTER ADDRESSES FOR CORE HOOKS =====
         // These are required for core hook deployments
@@ -104,6 +109,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.aggregationRouters[SONIC_CHAIN_ID] = AGGREGATION_ROUTER;
         configuration.aggregationRouters[GNOSIS_CHAIN_ID] = AGGREGATION_ROUTER;
         configuration.aggregationRouters[WORLDCHAIN_CHAIN_ID] = address(0); // Not deployed
+        configuration.aggregationRouters[HYPEREVM_CHAIN_ID] = address(0); // Not deployed
 
         configuration.odosRouters[MAINNET_CHAIN_ID] = ODOS_ROUTER_MAINNET;
         configuration.odosRouters[BASE_CHAIN_ID] = ODOS_ROUTER_BASE;
@@ -118,6 +124,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.odosRouters[SONIC_CHAIN_ID] = ODOS_ROUTER_SONIC;
         configuration.odosRouters[GNOSIS_CHAIN_ID] = address(0); // Not deployed
         configuration.odosRouters[WORLDCHAIN_CHAIN_ID] = address(0); // Not deployed
+        configuration.odosRouters[HYPEREVM_CHAIN_ID] = address(0); // Not deployed
 
         // ===== PENDLE ROUTER ADDRESSES =====
         configuration.pendleRouters[MAINNET_CHAIN_ID] = PENDLE_ROUTER_MAINNET;
@@ -133,6 +140,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.pendleRouters[SONIC_CHAIN_ID] = PENDLE_ROUTER_SONIC;
         configuration.pendleRouters[GNOSIS_CHAIN_ID] = address(0); // Not deployed
         configuration.pendleRouters[WORLDCHAIN_CHAIN_ID] = address(0); // Not deployed
+        configuration.pendleRouters[HYPEREVM_CHAIN_ID] = address(0); // Not deployed
 
         // ===== PENDLE PT AMORTIZED ORACLE ADDRESSES =====
         // Staging: 0x029FA76517Cc4d7c481c0BF1f31066eceCcb42B5
@@ -150,6 +158,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.pendlePTAmortizedOracles[SONIC_CHAIN_ID] = address(0);
         configuration.pendlePTAmortizedOracles[GNOSIS_CHAIN_ID] = address(0);
         configuration.pendlePTAmortizedOracles[WORLDCHAIN_CHAIN_ID] = address(0);
+        configuration.pendlePTAmortizedOracles[HYPEREVM_CHAIN_ID] = address(0);
 
         // ===== NATIVE TOKEN ADDRESSES =====
         configuration.nativeTokens[MAINNET_CHAIN_ID] = NATIVE_TOKEN_DEFAULT;
@@ -165,6 +174,7 @@ abstract contract ConfigCore is ConfigBase {
         configuration.nativeTokens[SONIC_CHAIN_ID] = NATIVE_TOKEN_DEFAULT;
         configuration.nativeTokens[GNOSIS_CHAIN_ID] = NATIVE_TOKEN_DEFAULT;
         configuration.nativeTokens[WORLDCHAIN_CHAIN_ID] = NATIVE_TOKEN_DEFAULT;
+        configuration.nativeTokens[HYPEREVM_CHAIN_ID] = NATIVE_TOKEN_DEFAULT;
 
         // ===== UNISWAP V4 POOL MANAGER ADDRESSES =====
         configuration.uniswapV4PoolManagers[MAINNET_CHAIN_ID] = 0x000000000004444c5dc75cB358380D2e3dE08A90;
@@ -180,5 +190,6 @@ abstract contract ConfigCore is ConfigBase {
         configuration.uniswapV4PoolManagers[SONIC_CHAIN_ID] = address(0); // Not deployed
         configuration.uniswapV4PoolManagers[GNOSIS_CHAIN_ID] = address(0); // Not deployed
         configuration.uniswapV4PoolManagers[WORLDCHAIN_CHAIN_ID] = 0xb1860D529182ac3BC1F51Fa2ABd56662b7D13f33;
+        configuration.uniswapV4PoolManagers[HYPEREVM_CHAIN_ID] = address(0); // Not deployed
     }
 }

--- a/script/utils/Constants.sol
+++ b/script/utils/Constants.sol
@@ -18,6 +18,7 @@ abstract contract Constants {
     string internal constant SONIC_KEY = "Sonic";
     string internal constant GNOSIS_KEY = "Gnosis";
     string internal constant WORLDCHAIN_KEY = "Worldchain";
+    string internal constant HYPEREVM_KEY = "HyperEVM";
     string internal constant SEPOLIA_KEY = "Sepolia";
     string internal constant ARB_SEPOLIA_KEY = "Arbitrum_Sepolia";
     string internal constant BASE_SEPOLIA_KEY = "Base_Sepolia";
@@ -56,6 +57,7 @@ abstract contract Constants {
     uint64 internal constant SONIC_CHAIN_ID = 146;
     uint64 internal constant GNOSIS_CHAIN_ID = 100;
     uint64 internal constant WORLDCHAIN_CHAIN_ID = 480;
+    uint64 internal constant HYPEREVM_CHAIN_ID = 999;
     // testnets
     uint64 internal constant SEPOLIA_CHAIN_ID = 11_155_111;
     uint64 internal constant ARB_SEPOLIA_CHAIN_ID = 421_613;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because production deployment/verification scripts now expect `HYPEREVM_RPC_URL` (env/1Password); missing credentials could cause CI/deploy verification runs to fail. Functional impact is otherwise additive (new chain mappings and mostly `address(0)` placeholders).
> 
> **Overview**
> Adds **production support for HyperEVM (chain `999`)** across deployment tooling and Solidity config.
> 
> Updates `networks-production.sh` to include HyperEVM in `NETWORKS`, map its name/RPC var, and load/export `HYPEREVM_MAINNET` from `HYPEREVM_RPC_URL` (CI + 1Password).
> 
> Extends `verify_v2_staging_prod.sh` to recognize HyperEVM deployment JSON suffixes and provide a chain-specific constructor-arg config (currently mostly *not deployed* placeholders).
> 
> Extends config contracts by adding `HYPEREVM_CHAIN_ID`/`HYPEREVM_KEY` in `Constants.sol`, wiring `chainNames[HYPEREVM_CHAIN_ID]` in `ConfigBase.sol`, and initializing HyperEVM entries in `ConfigCore.sol` mappings (primarily `address(0)` defaults).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 309787de10a5c145f45f72152f53f4d6ffa52669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->