### PR TITLE
fix: adapter count mismatch + deployment smoke test

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -398,3 +398,76 @@ jobs:
         run: |
           echo "## Treasury Configuration Test" >> $GITHUB_STEP_SUMMARY
           echo "✅ Smoke test completed (informational)" >> $GITHUB_STEP_SUMMARY
+
+  deployment-smoke-test:
+    runs-on: SuperformCore3
+    needs: ["test"]
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v4"
+        with:
+          submodules: true
+
+      - name: "Install Foundry"
+        uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "v1.4.4"
+
+      - name: "Install Foundry dependencies"
+        run: forge install
+
+      - name: "Install pnpm"
+        run: npm install -g pnpm@8
+
+      - name: "Install ModuleKit"
+        working-directory: ./lib/modulekit
+        run: pnpm install
+
+      - name: "Install Safe7579"
+        working-directory: ./lib/safe7579
+        run: pnpm install
+
+      - name: "Install Nexus"
+        working-directory: ./lib/nexus
+        run: yarn
+
+      - name: "Make deployment smoke test script executable"
+        run: chmod +x ./script/run/smoke_test_deployment.sh
+
+      - name: "Run deployment smoke tests"
+        id: deployment-smoke-test
+        run: |
+          echo "## Deployment Smoke Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Run the smoke test and capture output
+          set +e
+          ./script/run/smoke_test_deployment.sh prod > deployment_test_output.log 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          # Display the output
+          cat deployment_test_output.log
+
+          # Add results to summary
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✅ **All contracts verified on-chain**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️  **Some contracts missing on-chain**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This may be expected for networks with partial deployments." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Detailed Results" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          tail -30 deployment_test_output.log >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+          # Don't fail the CI for this - it's informational
+          exit 0
+
+      - name: "Add deployment test summary"
+        run: |
+          echo "## Deployment Verification" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Smoke test completed (informational)" >> $GITHUB_STEP_SUMMARY

--- a/script/DeployV2Core.s.sol
+++ b/script/DeployV2Core.s.sol
@@ -306,8 +306,9 @@ contract DeployV2Core is DeployV2Base, ConfigCore {
         // Max possible skips: 3 adapters + 31 hooks = 34 skipped contracts; keep a little headroom.
         string[] memory potentialSkips = new string[](37);
         uint256 skipCount = 0;
-        // Adapter contracts (4 contracts - conditionally deployed)
-        string[4] memory adapterContracts = ["AcrossV3Adapter", "AcrossV3AdapterV2", "DebridgeAdapter", "StargateAdapter"];
+        // Adapter contracts (5 contracts - conditionally deployed)
+        string[5] memory adapterContracts =
+            ["AcrossV3Adapter", "AcrossV3AdapterV2", "DebridgeAdapter", "StargateAdapter", "StargateAdapterV2"];
 
         // Start with all adapters, then decrement for missing configurations
         uint256 expectedAdapters = adapterContracts.length;
@@ -330,7 +331,7 @@ contract DeployV2Core is DeployV2Base, ConfigCore {
             potentialSkips[skipCount++] = "DebridgeAdapter";
         }
 
-        // StargateAdapter (requires lzEndpointV2 and tokenMessaging)
+        // StargateAdapter + StargateAdapterV2 (requires lzEndpointV2 and tokenMessaging)
         if (
             configuration.lzEndpointV2s[chainId] != address(0)
                 && configuration.stargateTokenMessagings[chainId] != address(0)
@@ -338,7 +339,7 @@ contract DeployV2Core is DeployV2Base, ConfigCore {
             availability.stargateAdapter = true;
             availability.stargateAdapterV2 = true;
         } else {
-            expectedAdapters -= 1; // StargateAdapter
+            expectedAdapters -= 2; // StargateAdapter + StargateAdapterV2
             potentialSkips[skipCount++] = "StargateAdapter";
             potentialSkips[skipCount++] = "StargateAdapterV2";
         }

--- a/script/SmokeTestDeployment.s.sol
+++ b/script/SmokeTestDeployment.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { ConfigBase } from "./utils/ConfigBase.sol";
+import { console2 } from "forge-std/console2.sol";
+
+/**
+ * @title SmokeTestDeployment
+ * @notice Smoke test that reads a chain's deployment JSON and verifies every listed contract has code on-chain
+ * @dev Usage: forge script script/SmokeTestDeployment.s.sol:SmokeTestDeployment \
+ *            --sig "run(uint256,uint64)" <env> <chainId> --rpc-url <rpc>
+ */
+contract SmokeTestDeployment is Script, ConfigBase {
+    /// @notice Environment setting for determining output path
+    uint256 internal currentEnv;
+
+    /// @notice Main entry point
+    /// @param env Environment (0 = prod, 2 = staging)
+    /// @param chainId Target chain ID to test
+    function run(uint256 env, uint64 chainId) public {
+        require(env == 0 || env == 2, "Invalid environment: must be 0 (prod) or 2 (staging)");
+
+        // Initialize chain name mappings
+        _setBaseConfiguration(env, "");
+
+        string memory envName = env == 0 ? "prod" : "staging";
+        string memory chainName = chainNames[chainId];
+        require(bytes(chainName).length > 0, "Unknown chain ID");
+
+        console2.log("====== DEPLOYMENT SMOKE TEST ======");
+        console2.log("Environment:", envName);
+        console2.log("Chain ID:", chainId);
+        console2.log("Chain Name:", chainName);
+        console2.log("");
+
+        // Read deployment JSON
+        string memory root = vm.envOr("SUPERFORM_PROJECT_ROOT", vm.projectRoot());
+        string memory outputPath = string(
+            abi.encodePacked(root, "/script/output/", envName, "/", vm.toString(uint256(chainId)), "/", chainName, "-latest.json")
+        );
+
+        require(vm.exists(outputPath), string(abi.encodePacked("DEPLOYMENT_FILE_NOT_FOUND: ", outputPath)));
+
+        string memory json = vm.readFile(outputPath);
+
+        // Parse all keys from the JSON
+        string[] memory keys = vm.parseJsonKeys(json, "$");
+        uint256 totalContracts = keys.length;
+        uint256 deployedCount = 0;
+        uint256 missingCount = 0;
+
+        console2.log("Total contracts in deployment file:", totalContracts);
+        console2.log("");
+
+        // Track missing contracts
+        string[] memory missingContracts = new string[](totalContracts);
+        address[] memory missingAddresses = new address[](totalContracts);
+
+        for (uint256 i = 0; i < totalContracts; i++) {
+            address addr = vm.parseJsonAddress(json, string(abi.encodePacked(".", keys[i])));
+            uint256 codeSize = addr.code.length;
+
+            if (codeSize > 0) {
+                deployedCount++;
+            } else {
+                missingContracts[missingCount] = keys[i];
+                missingAddresses[missingCount] = addr;
+                missingCount++;
+                console2.log("MISSING:", keys[i]);
+                console2.log("  Address:", addr);
+            }
+        }
+
+        console2.log("");
+        console2.log("====== RESULTS ======");
+        console2.log("Deployed:", deployedCount, "/", totalContracts);
+
+        if (missingCount > 0) {
+            console2.log("");
+            console2.log("Missing contracts:");
+            for (uint256 i = 0; i < missingCount; i++) {
+                console2.log(" ", missingContracts[i], "at", missingAddresses[i]);
+            }
+            console2.log("");
+            console2.log("DEPLOYMENT SMOKE TEST FAILED");
+            revert("DEPLOYMENT_SMOKE_TEST_FAILED: contracts missing on-chain");
+        } else {
+            console2.log("");
+            console2.log("DEPLOYMENT SMOKE TEST PASSED");
+        }
+        console2.log("====== SMOKE TEST COMPLETED ======");
+    }
+}

--- a/script/run/networks-production.sh
+++ b/script/run/networks-production.sh
@@ -6,22 +6,21 @@
 # Define production networks
 # Format: "CHAIN_ID:NetworkName:RPC_VAR"
 NETWORKS=(
-    # TEMP: Flare-only for ClaimRFLV2Hook deployment
+    "56:BNB:BSC_MAINNET"
+    "1:Ethereum:ETH_MAINNET"
+    "8453:Base:BASE_MAINNET"
+    "42161:Arbitrum:ARBITRUM_MAINNET"
+    "10:Optimism:OPTIMISM_MAINNET"
+    "137:Polygon:POLYGON_MAINNET"
+    "130:Unichain:UNICHAIN_MAINNET"
+    "43114:Avalanche:AVALANCHE_MAINNET"
+    "80094:Berachain:BERACHAIN_MAINNET"
+    "146:Sonic:SONIC_MAINNET"
+    "100:Gnosis:GNOSIS_MAINNET"
+    "480:Worldchain:WORLDCHAIN_MAINNET"
+    "999:HyperEVM:HYPEREVM_MAINNET"
     "14:Flare:FLARE_MAINNET"
-    # "1:Ethereum:ETH_MAINNET"
-    # "8453:Base:BASE_MAINNET"
-    # "56:BNB:BSC_MAINNET"
-    # "42161:Arbitrum:ARBITRUM_MAINNET"
-    # "10:Optimism:OPTIMISM_MAINNET"
-    # "137:Polygon:POLYGON_MAINNET"
-    # "130:Unichain:UNICHAIN_MAINNET"
-    # "43114:Avalanche:AVALANCHE_MAINNET"
-    # "80094:Berachain:BERACHAIN_MAINNET"
-    # "146:Sonic:SONIC_MAINNET"
-    # "100:Gnosis:GNOSIS_MAINNET"
-    # "480:Worldchain:WORLDCHAIN_MAINNET"
-    # "999:HyperEVM:HYPEREVM_MAINNET"
-    # "988:Stable:STABLE_MAINNET"
+    "988:Stable:STABLE_MAINNET"
 )
 
 # Network name mapping function

--- a/script/run/networks-staging.sh
+++ b/script/run/networks-staging.sh
@@ -6,15 +6,14 @@
 # Define staging networks
 # Format: "CHAIN_ID:NetworkName:RPC_VAR"
 NETWORKS=(
-    # TEMP: Flare-only for ClaimRFLV2Hook deployment
+    "56:BNB:BSC_MAINNET"
+    "1:Ethereum:ETH_MAINNET"
+    "8453:Base:BASE_MAINNET"
+    "42161:Arbitrum:ARBITRUM_MAINNET"
+    "43114:Avalanche:AVALANCHE_MAINNET"
+    "999:HyperEVM:HYPEREVM_MAINNET"
     "14:Flare:FLARE_MAINNET"
-    # "1:Ethereum:ETH_MAINNET"
-    # "8453:Base:BASE_MAINNET"
-    # "56:BNB:BSC_MAINNET"
-    # "42161:Arbitrum:ARBITRUM_MAINNET"
-    # "43114:Avalanche:AVALANCHE_MAINNET"
-    # "999:HyperEVM:HYPEREVM_MAINNET"
-    # "988:Stable:STABLE_MAINNET"
+    "988:Stable:STABLE_MAINNET"
 )
 
 # Network name mapping function

--- a/script/run/smoke_test_deployment.sh
+++ b/script/run/smoke_test_deployment.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+# Deployment Smoke Test Runner
+# Verifies all contracts listed in deployment JSON files are actually deployed on-chain
+#
+# Usage:
+#   ./script/run/smoke_test_deployment.sh prod              # Test all production networks
+#   ./script/run/smoke_test_deployment.sh staging            # Test all staging networks
+#   ./script/run/smoke_test_deployment.sh prod -n 56         # Test only BSC (prod)
+#   ./script/run/smoke_test_deployment.sh prod --verbose     # Verbose output
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Default values
+ENVIRONMENT="prod"
+FORGE_ENV=0
+SPECIFIC_NETWORK=""
+VERBOSE=false
+DRY_RUN=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 <environment> [OPTIONS]"
+    echo ""
+    echo "Verify all deployed contracts have code on-chain"
+    echo ""
+    echo "ARGUMENTS:"
+    echo "  environment            Required: 'staging' or 'prod'"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -n, --network CHAIN_ID  Test specific network only"
+    echo "  -v, --verbose          Enable verbose output"
+    echo "  -d, --dry-run          Show what would be tested without running"
+    echo "  -h, --help             Show this help message"
+}
+
+parse_args() {
+    if [[ $# -lt 1 ]]; then
+        echo "Missing required argument: environment"
+        usage
+        exit 1
+    fi
+
+    if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    ENVIRONMENT="$1"
+    shift
+
+    case "$ENVIRONMENT" in
+        prod)
+            FORGE_ENV=0
+            source "$SCRIPT_DIR/networks-production.sh"
+            ;;
+        staging)
+            FORGE_ENV=2
+            source "$SCRIPT_DIR/networks-staging.sh"
+            ;;
+        *)
+            echo "Invalid environment: $ENVIRONMENT (must be 'staging' or 'prod')"
+            exit 1
+            ;;
+    esac
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -n|--network)
+                SPECIFIC_NETWORK="$2"
+                shift 2
+                ;;
+            -v|--verbose)
+                VERBOSE=true
+                shift
+                ;;
+            -d|--dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ -n "$SPECIFIC_NETWORK" ]]; then
+        if ! is_network_supported "$SPECIFIC_NETWORK"; then
+            echo "Network $SPECIFIC_NETWORK is not supported in $ENVIRONMENT"
+            exit 1
+        fi
+    fi
+}
+
+log() {
+    local level=$1
+    shift
+    local message="$*"
+    case $level in
+        "INFO")    echo -e "${BLUE}ℹ️  $message${NC}" ;;
+        "SUCCESS") echo -e "${GREEN}✅ $message${NC}" ;;
+        "WARNING") echo -e "${YELLOW}⚠️  $message${NC}" ;;
+        "ERROR")   echo -e "${RED}❌ $message${NC}" ;;
+        *)         echo "$message" ;;
+    esac
+}
+
+run_network_test() {
+    local network_id=$1
+    local network_name=$(get_network_name "$network_id")
+    local rpc_url=$(get_rpc_url "$network_id")
+
+    log "INFO" "Testing $network_name (Chain ID: $network_id)"
+
+    if [[ -z "$rpc_url" ]]; then
+        log "ERROR" "No RPC URL configured for $network_name"
+        return 1
+    fi
+
+    local forge_cmd="forge script script/SmokeTestDeployment.s.sol:SmokeTestDeployment"
+    forge_cmd="$forge_cmd --sig \"run(uint256,uint64)\" $FORGE_ENV $network_id"
+    forge_cmd="$forge_cmd --rpc-url \"$rpc_url\""
+
+    if [[ "$VERBOSE" == "true" ]]; then
+        forge_cmd="$forge_cmd -vv"
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "INFO" "Would run: $forge_cmd"
+        return 0
+    fi
+
+    local start_time=$(date +%s)
+
+    set +e
+    local output
+    output=$(eval "$forge_cmd" 2>&1)
+    local forge_exit_code=$?
+    set -e
+
+    echo "$output"
+
+    local end_time=$(date +%s)
+    local duration=$((end_time - start_time))
+
+    if echo "$output" | grep -q "DEPLOYMENT SMOKE TEST FAILED"; then
+        log "ERROR" "$network_name deployment smoke test FAILED (${duration}s)"
+        return 1
+    elif echo "$output" | grep -q "DEPLOYMENT SMOKE TEST PASSED"; then
+        log "SUCCESS" "$network_name deployment smoke test passed (${duration}s)"
+        return 0
+    elif [[ $forge_exit_code -eq 0 ]]; then
+        log "SUCCESS" "$network_name deployment smoke test passed (${duration}s)"
+        return 0
+    else
+        log "ERROR" "$network_name deployment smoke test failed with exit code $forge_exit_code (${duration}s)"
+        return 1
+    fi
+}
+
+main() {
+    parse_args "$@"
+    cd "$PROJECT_ROOT"
+
+    log "INFO" "Starting Deployment Smoke Tests"
+    log "INFO" "Environment: $(echo "$ENVIRONMENT" | sed 's/prod/Production/;s/staging/Staging/')"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "WARNING" "DRY RUN MODE - No tests will be executed"
+    fi
+
+    echo ""
+
+    # Load RPC URLs
+    if [[ "$DRY_RUN" != "true" ]]; then
+        if [[ "${CI:-}" == "true" ]]; then
+            log "INFO" "Loading RPC URLs from environment variables (CI mode)..."
+            if type load_rpc_urls_ci &>/dev/null; then
+                load_rpc_urls_ci || log "WARNING" "Some RPC URLs failed to load"
+            else
+                load_rpc_urls || log "WARNING" "Some RPC URLs failed to load"
+            fi
+        else
+            log "INFO" "Loading RPC URLs from credential manager..."
+            load_rpc_urls || log "WARNING" "Some RPC URLs failed to load"
+        fi
+        echo ""
+    fi
+
+    # Determine networks to test
+    local networks_to_test=()
+    if [[ -n "$SPECIFIC_NETWORK" ]]; then
+        networks_to_test=("$SPECIFIC_NETWORK")
+        log "INFO" "Testing specific network: $(get_network_name "$SPECIFIC_NETWORK")"
+    else
+        readarray -t networks_to_test < <(get_supported_networks)
+        log "INFO" "Testing ${#networks_to_test[@]} networks"
+    fi
+
+    echo ""
+
+    local total_networks=${#networks_to_test[@]}
+    local passed_tests=0
+    local failed_tests=0
+    local failed_networks=()
+
+    for network_id in "${networks_to_test[@]}"; do
+        echo "----------------------------------------"
+        if run_network_test "$network_id"; then
+            passed_tests=$((passed_tests + 1))
+        else
+            failed_tests=$((failed_tests + 1))
+            failed_networks+=("$(get_network_name "$network_id") (ID: $network_id)")
+        fi
+        echo ""
+    done
+
+    echo "========================================"
+    log "INFO" "Deployment Smoke Test Summary"
+    echo "========================================"
+    log "INFO" "Total Networks: $total_networks"
+    log "SUCCESS" "Passed: $passed_tests"
+
+    if [[ $failed_tests -gt 0 ]]; then
+        log "ERROR" "Failed: $failed_tests"
+        echo ""
+        log "ERROR" "Failed Networks:"
+        for failed_network in "${failed_networks[@]}"; do
+            echo "  • $failed_network"
+        done
+        echo ""
+        log "ERROR" "Deployment smoke tests completed with failures"
+        exit 1
+    else
+        echo ""
+        log "SUCCESS" "All deployment smoke tests passed!"
+        exit 0
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Fix `adapterContracts` array missing `StargateAdapterV2` (`string[4]` → `string[5]`), causing bytecode existence check to skip it
- Fix `expectedAdapters` decrement for Stargate from `-1` to `-2` (accounts for both `StargateAdapter` + `StargateAdapterV2`)
- Add deployment smoke test that verifies all contracts in deployment JSONs have code on-chain
- Add `deployment-smoke-test` CI job (runs after tests, informational — doesn't block CI)
- Uncomment all networks in staging + production configs (were temporarily restricted to Flare-only)

## Test plan
- [ ] `forge build` passes
- [ ] `./script/run/smoke_test_deployment.sh prod -n 56` verifies BSC contracts
- [ ] CI `deployment-smoke-test` job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)