### PR TITLE
docs: align hook NatSpec with bundler config

### DIFF
--- a/src/hooks/bridges/debridge/DeBridgeSendOrderAndExecuteOnDstHook.sol
+++ b/src/hooks/bridges/debridge/DeBridgeSendOrderAndExecuteOnDstHook.sol
@@ -37,7 +37,7 @@ import {
 /// @notice         address executorAddress = BytesLib.toAddress(data, 158);
 /// @notice         uint256 executionFee = BytesLib.toUint256(data, 178);
 /// @notice         bool allowDelayedExecution = _decodeBool(data, 210);
-/// @notice         bool requireSuccessfullExecution = _decodeBool(data, 211);
+/// @notice         bool requireSuccessfulExecution = _decodeBool(data, 211);
 /// @notice         uint256 destinationMessage_paramLength = BytesLib.toUint256(data, 212);
 /// @notice         bytes destinationMessage = BytesLib.slice(data, 244, destinationMessage_paramLength);
 /// @notice         uint256 takeTokenAddress_paramLength = BytesLib.toUint256(data, 244 +
@@ -75,7 +75,7 @@ import {
 /// @notice         bytes affiliateFee = BytesLib.slice(data, 520 + destinationMessage_paramLength +
 /// takeTokenAddress_paramLength + receiverDst_paramLength + orderAuthorityAddressDst_paramLength +
 /// allowedTakerDst_paramLength + allowedCancelBeneficiarySrc_paramLength, affiliateFee_paramLength);
-/// @notice         uint256 referralCode = BytesLib.toUint256(data, 520 + destinationMessage_paramLength +
+/// @notice         uint32 referralCode = BytesLib.toUint32(data, 520 + destinationMessage_paramLength +
 /// takeTokenAddress_paramLength + receiverDst_paramLength + orderAuthorityAddressDst_paramLength +
 /// allowedTakerDst_paramLength + allowedCancelBeneficiarySrc_paramLength + affiliateFee_paramLength);
 contract DeBridgeSendOrderAndExecuteOnDstHook is BaseHook, ISuperHookContextAware, ISuperHookInflowOutflow, ISuperHookOutflow {

--- a/src/hooks/bridges/stargate/StargateSendHookV2.sol
+++ b/src/hooks/bridges/stargate/StargateSendHookV2.sol
@@ -43,11 +43,14 @@ import {
 /// @notice         uint256 minAmountLD = BytesLib.toUint256(data, 192);
 /// @notice         bool usePrevHookAmount = _decodeBool(data, 224);
 /// @notice         uint8 mode = BytesLib.toUint8(data, 225);
-/// @notice         uint256 extraOptionsLength = BytesLib.toUint256(data, 226);
-/// @notice         bytes extraOptions = BytesLib.slice(data, 258, extraOptionsLength);
-/// @notice         uint256 composeMsgLength = BytesLib.toUint256(data, 258 + extraOptionsLength);
-/// @notice         bytes composeMsg = BytesLib.slice(data, 290 + extraOptionsLength, composeMsgLength);
-///                 V2: composeMsg = abi.encode(initData) — 1-field only, no executorCalldata/account/dstTokens/intentAmounts
+/// @notice         uint256 extraOptions_paramLength = BytesLib.toUint256(data, 226);
+/// @notice         bytes extraOptions = BytesLib.slice(data, 258, extraOptions_paramLength);
+/// @notice         uint256 composeMsg_paramLength = BytesLib.toUint256(data, 258 + extraOptions_paramLength);
+/// @notice         bytes composeMsg = BytesLib.slice(data, 290 + extraOptions_paramLength, composeMsg_paramLength);
+/// @notice         address recipient_skipParam = BytesLib.toAddress(data, 0);
+/// @notice         address outputToken_skipParam = BytesLib.toAddress(data, 0);
+/// @notice         uint256 destinationChainId_skipParam = BytesLib.toUint256(data, 0);
+/// @dev V2: composeMsg = abi.encode(initData) — 1-field only, no executorCalldata/account/dstTokens/intentAmounts
 contract StargateSendHookV2 is BaseHook, ISuperHookContextAware, ISuperHookInflowOutflow, ISuperHookOutflow {
     /*//////////////////////////////////////////////////////////////
                                  STORAGE

--- a/src/hooks/claim/flare/WithdrawRFLRHookV2.sol
+++ b/src/hooks/claim/flare/WithdrawRFLRHookV2.sol
@@ -29,7 +29,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 /// @dev data has the following structure (standard 52-byte strategy header + hook-specific):
 /// @notice         bytes32 placeholder0 = BytesLib.toBytes32(data, 0);
 /// @notice         address placeholder1 = BytesLib.toAddress(data, 32);
-/// @notice         uint256 minOut = BytesLib.toUint256(data, 52);
+/// @notice         uint256 minOut_optional = BytesLib.toUint256(data, 52);
 contract WithdrawRFLRHookV2 is BaseHook, ISuperHookInflowOutflow {
     /*//////////////////////////////////////////////////////////////
                               ERRORS

--- a/src/hooks/claim/flare/WithdrawVestedRFLRHookV2.sol
+++ b/src/hooks/claim/flare/WithdrawVestedRFLRHookV2.sol
@@ -31,7 +31,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 /// @dev data has the following structure (standard 52-byte strategy header + hook-specific):
 /// @notice         bytes32 placeholder0 = BytesLib.toBytes32(data, 0);
 /// @notice         address placeholder1 = BytesLib.toAddress(data, 32);
-/// @notice         uint256 minOut = BytesLib.toUint256(data, 52);
+/// @notice         uint256 minOut_optional = BytesLib.toUint256(data, 52);
 contract WithdrawVestedRFLRHookV2 is BaseHook, ISuperHookInflowOutflow {
     using SafeCast for uint256;
 

--- a/src/hooks/tokens/permit2/BatchTransferFromHook.sol
+++ b/src/hooks/tokens/permit2/BatchTransferFromHook.sol
@@ -25,7 +25,8 @@ import { HookSubTypes } from "../../../libraries/HookSubTypes.sol";
 /// @notice     bytes tokens = BytesLib.slice(data, 136, 20 * tokensLength);
 /// @notice     bytes amounts = BytesLib.slice(data, 136 + 20 * tokensLength, 32 * tokensLength);
 /// @notice     bytes nonces = BytesLib.slice(data, 136 + 20 * tokensLength + 32 * tokensLength, 6 * tokensLength);
-/// @notice     bytes signature = BytesLib.slice(data, data.length - 65, 65);
+/// @notice     bytes signature = BytesLib.slice(data, 136 + 20 * tokensLength + 32 * tokensLength + 6 * tokensLength,
+/// 65);
 contract BatchTransferFromHook is BaseHook, ISuperHookInflowOutflow, ISuperHookOutflow {
     using SafeCast for uint256;
 


### PR DESCRIPTION
## Summary
- Align five hook calldata NatSpec layouts with `bundler/hooks_config.local.json`.
- Add the `_optional`, `_paramLength`, and `_skipParam` directives consumed by the bundler build-path parser.
- Correct the deBridge packed-input name and referral-code width in its NatSpec.
- Keep runtime Solidity behavior unchanged; every committed line is a `///` comment.

## Validation
- `git diff --check`
- Automated normalized-layout comparison for all five hooks against `hooks_config.local.json`
- Comment-only staged-diff guard
- `forge build --skip test`

Full `forge build` still reproduces the existing `dev` failure where three test helpers are declared `view` but call `vm.getRecordedLogs()`. This PR does not touch those tests.

## Notes
- `BatchTransferFromHook` now documents the canonical contiguous signature offset; runtime decoding still reads the final 65 bytes.
- Stargate `_skipParam` entries are bundler sideband metadata and are not decoded on chain.